### PR TITLE
feat: 찬주, 혜린 train code 통합 & Curriculum Step 1~3 실험

### DIFF
--- a/RL/environment.py
+++ b/RL/environment.py
@@ -18,8 +18,17 @@ def get_mask(state, flights, assigned, constraint):
     for f in flights:
         if assigned[f["id"]]:
             mask.append(0)
-        else:
-            mask.append(1)
+            continue
+
+        flight_time = f["arr_time"] - f["dep_time"]
+
+        valid = (
+            f["origin"] == state["current_airport"] and
+            f["dep_time"] >= state["current_time"] and
+            state["duty_time"] + flight_time <= constraint["max_duty"]
+        )
+
+        mask.append(1 if valid else 0)
 
     mask.append(1)  # END 항상 허용
     return mask

--- a/log/0403_RESULTS.md
+++ b/log/0403_RESULTS.md
@@ -1,0 +1,136 @@
+# Curriculum Learning 결과 (2026-04-03)
+
+## 실험 환경
+
+- 데이터: BTS Delta (T_ONTIME_MARKETING.csv)
+- 모델: FlightEncoder(Embedding + FiLM + Transformer) + PointerDecoder
+- 학습: REINFORCE + greedy rollout baseline
+- optimizer: Adam, lr=1e-4
+- gradient clipping: max_norm=1.0
+- **seed: 42 (고정)** - 재현 가능하도록
+
+---
+
+## Step 1: 50 flights + constraint 고정 (max_duty=10h)
+
+> 목표: 모델 구조가 작동하는지 확인
+
+```
+처음 50ep 평균 pairings: 24.7
+마지막 50ep 평균 pairings: 23.9
+→ ✅ 수렴 확인
+```
+
+- greedy pairings가 23~25에서 안정
+- 중간에 불안정 구간 있음 (Ep 100, 450에서 spike)
+- 1000 에피소드 학습
+
+---
+
+## Step 2: 300 flights + constraint 고정 (max_duty=10h)
+
+> 목표: 스케일업해도 수렴하는지 확인
+
+```
+처음 50ep 평균 pairings: 136.2
+마지막 50ep 평균 pairings: 133.9
+→ ✅ 수렴 확인 (seed=42)
+```
+
+- 44개 공항, 300개 flight
+- 500 에피소드 학습
+- 참고: seed 미고정 시 초기화에 따라 불안정할 수 있음 (294까지 발산한 케이스 있었음)
+
+---
+
+## Step 3: FiLM 검증 — 같은 flights, 다른 constraint
+
+> 목표: FiLM이 constraint를 반영하는지 확인 (박사님 핵심 요청)
+
+```
+max_duty=  6h → pairings: 30
+max_duty=  8h → pairings: 25
+max_duty= 10h → pairings: 25
+max_duty= 12h → pairings: 21
+max_duty= 14h → pairings: 19
+```
+
+→ **✅ FiLM 작동 확인**
+
+- constraint가 strict할수록 pairing 수 증가 (짧은 pairing)
+- constraint가 relaxed할수록 pairing 수 감소 (긴 pairing)
+- 동일 flights에 대해 constraint만 바꿨을 때 결과가 달라짐
+
+---
+
+## 판단 과정
+
+| 기준              | 결과                    |
+| ----------------- | ----------------------- |
+| reward 증가 추세  | ✅ Step 1, 2 모두 수렴  |
+| constraint별 차이 | ✅ FiLM이 반영하고 있음 |
+| → RL 진행 가능    | ✅                      |
+
+---
+
+## Reward 비교 실험 (Step 1 기준, 50 flights, max_duty=10h)
+
+### 복잡 reward
+
+```
+reward = 연결보상(+1/-1) + waiting penalty(-0.05*wait)
+       + duty penalty(-2*excess) + early/late(-0.01*dep)
+       + final(-3*remaining)
+```
+
+```
+처음 50ep 평균 pairings: 24.7
+마지막 50ep 평균 pairings: 23.9
+```
+
+### 단순 reward
+
+```
+reward = -len(pairings)
+```
+
+```
+처음 50ep 평균 pairings: 28.9
+마지막 50ep 평균 pairings: 24.4
+```
+
+### FiLM 검증 비교
+
+| max_duty | 복잡 reward | 단순 reward |
+| -------- | ----------- | ----------- |
+| 6h       | 30          | 32          |
+| 8h       | 25          | 27          |
+| 10h      | 25          | 24          |
+| 12h      | 21          | 19          |
+| 14h      | 19          | 18          |
+
+### 비교 분석
+
+- **수렴**: 둘 다 수렴함
+- **FiLM**: 둘 다 constraint별 차이 뚜렷 (FiLM 작동)
+- **최종 성능**: 단순 reward가 relaxed constraint(12h, 14h)에서 더 적은 pairings
+- **안정성**: 단순 reward가 spike 덜 심함
+- **초기 수렴 속도**: 복잡 reward가 더 빠름 (24.7 vs 28.9 시작)
+
+→ 단순 reward로 시작하되, 복잡 reward 요소를 하나씩 추가하며 ablation 가능
+
+---
+
+## 발생한 이슈
+
+1. **학습 불안정**: seed 미고정 시 Step 2에서 발산 (294 pairings). seed=42 고정으로 해결
+2. **sample < greedy**: sample rollout이 greedy보다 거의 항상 나쁨 (exploration이 아직 비효율적)
+3. **Step 2 수렴 폭 작음**: 136.2 → 133.9 (500ep). 에피소드 수 늘리면 더 줄어들 가능성
+
+---
+
+## 다음 단계
+
+- [ ] 학습 안정화 (spike 원인 분석)
+- [ ] reward ablation (단순 → +연결보상 → +waiting → ... 하나씩 추가)
+- [ ] constraint 확장 (min_rest, max_days 등)

--- a/train.py
+++ b/train.py
@@ -1,0 +1,217 @@
+"""
+찬주 model/ + 혜린 RL/environment 통합 학습 스크립트
+- encoder: 찬주 (FlightEncoder — Embedding + FiLM + Transformer)
+- decoder: 찬주 (PointerDecoder — Pointer Attention + hard masking)
+- environment: 혜린 (mask + step + reward)
+- loader: 혜린 (BTS CSV → flight dict)
+"""
+
+import sys
+import torch
+import torch.optim as optim
+from torch.distributions import Categorical
+
+# 찬주 모델 (model/ 폴더 먼저 잡히도록)
+from model import FlightEncoder, PointerDecoder
+
+# 혜린 코드 (RL/ 폴더)
+sys.path.insert(0, "RL")
+from loader import load_flights
+from environment import get_mask, step, init_state, final_reward
+
+
+def flights_to_tensors(flights):
+    """혜린 flight dict → 찬주 encoder 입력 tensor 변환"""
+    origins = torch.tensor([f["origin"] for f in flights])
+    dests = torch.tensor([f["dest"] for f in flights])
+    dep_times = torch.tensor([f["dep_time"] for f in flights], dtype=torch.float32)
+    arr_times = torch.tensor([f["arr_time"] for f in flights], dtype=torch.float32)
+    return origins, dests, dep_times, arr_times
+
+
+def state_to_vec(state, encoder):
+    """혜린 state dict → 찬주 decoder 입력 tensor 변환"""
+    airport_emb = encoder.airport_emb(torch.tensor(state["current_airport"]))
+    return torch.cat([
+        airport_emb,
+        torch.tensor([state["current_time"]], dtype=torch.float32),
+        torch.tensor([state["duty_time"]], dtype=torch.float32),
+    ])
+
+
+def run_episode(flights, constraint, encoder, decoder, encoded, greedy=False):
+    """
+    혜린 environment + 찬주 model로 에피소드 진행
+
+    Returns:
+        total_reward, log_probs, entropies, n_pairings
+    """
+    assigned = {f["id"]: False for f in flights}
+    state = init_state(flights)
+
+    log_probs = []
+    entropies = []
+    total_reward = 0
+    n_pairings = 0
+
+    while True:
+        # 혜린 mask
+        mask_list = get_mask(state, flights, assigned, constraint)
+        mask = torch.tensor(mask_list, dtype=torch.float32)
+
+        # valid한 flight가 없으면 (END만 남으면) 종료
+        if sum(mask_list[:-1]) == 0:
+            n_pairings += 1
+            total_reward += -1.0
+
+            # 미배정 flight 남아있으면 새 pairing 시작
+            unassigned = [f for f in flights if not assigned[f["id"]]]
+            if len(unassigned) == 0:
+                break
+
+            # 가장 이른 미배정 flight로 새 pairing 시작
+            start = unassigned[0]
+            assigned[start["id"]] = True
+            state = {
+                "current_airport": start["dest"],
+                "current_time": start["arr_time"],
+                "duty_time": start["arr_time"] - start["dep_time"],
+                "remaining": sum(1 for v in assigned.values() if not v),
+            }
+            continue
+
+        # 찬주 decoder
+        state_vec = state_to_vec(state, encoder)
+        probs = decoder(encoded, state_vec, mask)
+
+        if greedy:
+            action = probs.argmax().item()
+        else:
+            dist = Categorical(probs)
+            a = dist.sample()
+            log_probs.append(dist.log_prob(a))
+            entropies.append(dist.entropy())
+            action = a.item()
+
+        # END action
+        if action == len(flights):
+            n_pairings += 1
+            total_reward += -1.0
+
+            # 미배정 flight 남아있으면 새 pairing 시작
+            unassigned = [f for f in flights if not assigned[f["id"]]]
+            if len(unassigned) == 0:
+                break
+
+            start = unassigned[0]
+            assigned[start["id"]] = True
+            state = {
+                "current_airport": start["dest"],
+                "current_time": start["arr_time"],
+                "duty_time": start["arr_time"] - start["dep_time"],
+                "remaining": sum(1 for v in assigned.values() if not v),
+            }
+            continue
+
+        # 혜린 step (assigned도 내부에서 업데이트)
+        state, r, done = step(state, action, flights, assigned, constraint)
+        total_reward += r
+
+        if done:
+            break
+
+    # 혜린 final reward
+    total_reward += final_reward(assigned)
+
+    return total_reward, log_probs, entropies, n_pairings
+
+
+def train():
+    # 데이터 로드 (혜린 loader)
+    flights = load_flights("RL/data/T_ONTIME_MARKETING.csv", limit=50)
+    n_airports = max(max(f["origin"], f["dest"]) for f in flights) + 1
+
+    print(f"flights: {len(flights)}개, airports: {n_airports}개")
+    print()
+
+    # 찬주 모델 생성
+    encoder = FlightEncoder(
+        n_airports=n_airports,
+        constraint_dim=1,
+        airport_emb_dim=32,
+        d_model=128,
+    )
+    decoder = PointerDecoder(d_model=128, airport_emb_dim=32)
+
+    # 전체 파라미터 합쳐서 optimizer
+    params = list(encoder.parameters()) + list(decoder.parameters())
+    optimizer = optim.Adam(params, lr=1e-4)  # lr 낮춤 (안정성)
+
+    # flight → tensor (1번만)
+    origins, dests, dep_times, arr_times = flights_to_tensors(flights)
+
+    for episode in range(1000):
+        # constraint 번갈아 (FiLM 검증용)
+        constraint = {"max_duty": 8.0 if episode % 2 == 0 else 14.0}
+        c_tensor = torch.tensor([constraint["max_duty"]], dtype=torch.float32)
+
+        # encode (에피소드당 1번)
+        encoded = encoder(origins, dests, dep_times, arr_times, c_tensor)
+
+        # ── sample rollout (학습용) ──
+        reward_s, log_probs, entropies, pairings_s = run_episode(
+            flights, constraint, encoder, decoder, encoded, greedy=False
+        )
+
+        if len(log_probs) == 0:
+            continue
+
+        # ── greedy rollout (baseline) ──
+        with torch.no_grad():
+            encoded_g = encoder(origins, dests, dep_times, arr_times, c_tensor)
+            reward_g, _, _, pairings_g = run_episode(
+                flights, constraint, encoder, decoder, encoded_g, greedy=True
+            )
+
+        # advantage = sample - greedy (sample이 나았으면 양수)
+        advantage = (reward_s - reward_g) / 10.0
+
+        # REINFORCE loss + entropy bonus
+        loss = torch.stack([
+            -lp * advantage - 0.01 * ent
+            for lp, ent in zip(log_probs, entropies)
+        ]).sum()
+
+        optimizer.zero_grad()
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(params, max_norm=1.0)  # gradient clipping
+        optimizer.step()
+
+        if episode % 20 == 0:
+            print(
+                f"Ep {episode:4d} | "
+                f"sample: {reward_s:7.1f} (p={pairings_s:2d}) | "
+                f"greedy: {reward_g:7.1f} (p={pairings_g:2d}) | "
+                f"adv: {advantage:6.2f} | "
+                f"duty: {constraint['max_duty']:2.0f}h | "
+                f"loss: {loss.item():8.3f}"
+            )
+
+    # ── FiLM 검증: constraint별 greedy 결과 비교 ──
+    print()
+    print("=" * 60)
+    print("FiLM 검증: 같은 flights, 다른 constraint")
+    print("=" * 60)
+
+    for duty in [6.0, 8.0, 10.0, 12.0, 14.0]:
+        c = torch.tensor([duty], dtype=torch.float32)
+        with torch.no_grad():
+            enc = encoder(origins, dests, dep_times, arr_times, c)
+            reward, _, _, n_pair = run_episode(
+                flights, {"max_duty": duty}, encoder, decoder, enc, greedy=True
+            )
+        print(f"  max_duty={duty:4.0f}h → pairings: {n_pair:3d}, reward: {reward:7.1f}")
+
+
+if __name__ == "__main__":
+    train()

--- a/train_step1.py
+++ b/train_step1.py
@@ -1,0 +1,202 @@
+"""
+Curriculum Step 1: 50 flights + constraint 고정 (max_duty=10h)
+목표: constraint 고정 상태에서 reward가 올라가는지 (수렴 확인)
+"""
+
+import sys
+import random
+import torch
+import torch.optim as optim
+from torch.distributions import Categorical
+
+SEED = 42
+random.seed(SEED)
+torch.manual_seed(SEED)
+
+from model import FlightEncoder, PointerDecoder
+
+sys.path.insert(0, "RL")
+from loader import load_flights
+from environment import get_mask, step, init_state, final_reward
+
+
+def flights_to_tensors(flights):
+    origins = torch.tensor([f["origin"] for f in flights])
+    dests = torch.tensor([f["dest"] for f in flights])
+    dep_times = torch.tensor([f["dep_time"] for f in flights], dtype=torch.float32)
+    arr_times = torch.tensor([f["arr_time"] for f in flights], dtype=torch.float32)
+    return origins, dests, dep_times, arr_times
+
+
+def state_to_vec(state, encoder):
+    airport_emb = encoder.airport_emb(torch.tensor(state["current_airport"]))
+    return torch.cat([
+        airport_emb,
+        torch.tensor([state["current_time"]], dtype=torch.float32),
+        torch.tensor([state["duty_time"]], dtype=torch.float32),
+    ])
+
+
+def run_episode(flights, constraint, encoder, decoder, encoded, greedy=False):
+    assigned = {f["id"]: False for f in flights}
+    state = init_state(flights)
+
+    log_probs = []
+    entropies = []
+    total_reward = 0
+    n_pairings = 0
+
+    while True:
+        mask_list = get_mask(state, flights, assigned, constraint)
+        mask = torch.tensor(mask_list, dtype=torch.float32)
+
+        if sum(mask_list[:-1]) == 0:
+            n_pairings += 1
+            total_reward += -1.0
+
+            unassigned = [f for f in flights if not assigned[f["id"]]]
+            if len(unassigned) == 0:
+                break
+
+            start = unassigned[0]
+            assigned[start["id"]] = True
+            state = {
+                "current_airport": start["dest"],
+                "current_time": start["arr_time"],
+                "duty_time": start["arr_time"] - start["dep_time"],
+                "remaining": sum(1 for v in assigned.values() if not v),
+            }
+            continue
+
+        state_vec = state_to_vec(state, encoder)
+        probs = decoder(encoded, state_vec, mask)
+
+        if greedy:
+            action = probs.argmax().item()
+        else:
+            dist = Categorical(probs)
+            a = dist.sample()
+            log_probs.append(dist.log_prob(a))
+            entropies.append(dist.entropy())
+            action = a.item()
+
+        if action == len(flights):
+            n_pairings += 1
+            total_reward += -1.0
+
+            unassigned = [f for f in flights if not assigned[f["id"]]]
+            if len(unassigned) == 0:
+                break
+
+            start = unassigned[0]
+            assigned[start["id"]] = True
+            state = {
+                "current_airport": start["dest"],
+                "current_time": start["arr_time"],
+                "duty_time": start["arr_time"] - start["dep_time"],
+                "remaining": sum(1 for v in assigned.values() if not v),
+            }
+            continue
+
+        state, r, done = step(state, action, flights, assigned, constraint)
+        total_reward += r
+
+        if done:
+            break
+
+    total_reward += final_reward(assigned)
+    return total_reward, log_probs, entropies, n_pairings
+
+
+def train():
+    flights = load_flights("RL/data/T_ONTIME_MARKETING.csv", limit=50)
+    n_airports = max(max(f["origin"], f["dest"]) for f in flights) + 1
+
+    # ★ constraint 고정
+    CONSTRAINT = {"max_duty": 10.0}
+    c_tensor = torch.tensor([CONSTRAINT["max_duty"]], dtype=torch.float32)
+
+    print(f"=== Curriculum Step 1 ===")
+    print(f"flights: {len(flights)}개, airports: {n_airports}개")
+    print(f"constraint: max_duty={CONSTRAINT['max_duty']}h (고정)")
+    print()
+
+    encoder = FlightEncoder(n_airports=n_airports)
+    decoder = PointerDecoder()
+
+    params = list(encoder.parameters()) + list(decoder.parameters())
+    optimizer = optim.Adam(params, lr=1e-4)
+
+    origins, dests, dep_times, arr_times = flights_to_tensors(flights)
+
+    # 기록용
+    greedy_rewards = []
+    greedy_pairings = []
+
+    for episode in range(1000):
+        encoded = encoder(origins, dests, dep_times, arr_times, c_tensor)
+
+        # sample rollout
+        reward_s, log_probs, entropies, pairings_s = run_episode(
+            flights, CONSTRAINT, encoder, decoder, encoded, greedy=False
+        )
+
+        if len(log_probs) == 0:
+            continue
+
+        # greedy rollout (baseline)
+        with torch.no_grad():
+            encoded_g = encoder(origins, dests, dep_times, arr_times, c_tensor)
+            reward_g, _, _, pairings_g = run_episode(
+                flights, CONSTRAINT, encoder, decoder, encoded_g, greedy=True
+            )
+
+        greedy_rewards.append(reward_g)
+        greedy_pairings.append(pairings_g)
+
+        advantage = (reward_s - reward_g) / 10.0
+
+        loss = torch.stack([
+            -lp * advantage - 0.01 * ent
+            for lp, ent in zip(log_probs, entropies)
+        ]).sum()
+
+        optimizer.zero_grad()
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(params, max_norm=1.0)
+        optimizer.step()
+
+        if episode % 50 == 0:
+            # 최근 50개 평균
+            recent_r = greedy_rewards[-50:]
+            recent_p = greedy_pairings[-50:]
+            avg_r = sum(recent_r) / len(recent_r)
+            avg_p = sum(recent_p) / len(recent_p)
+
+            print(
+                f"Ep {episode:4d} | "
+                f"greedy reward: {reward_g:7.1f} (avg50: {avg_r:6.1f}) | "
+                f"greedy pairings: {pairings_g:2d} (avg50: {avg_p:5.1f}) | "
+                f"sample pairings: {pairings_s:2d} | "
+                f"adv: {advantage:6.2f}"
+            )
+
+    # 최종 결과
+    print()
+    print("=" * 60)
+    print("Step 1 결과")
+    print("=" * 60)
+
+    first50 = greedy_pairings[:50]
+    last50 = greedy_pairings[-50:]
+    print(f"  처음 50ep 평균 pairings: {sum(first50)/len(first50):.1f}")
+    print(f"  마지막 50ep 평균 pairings: {sum(last50)/len(last50):.1f}")
+
+    improved = sum(first50)/len(first50) > sum(last50)/len(last50)
+    print(f"  수렴 여부: {'줄어듦 (수렴 중)' if improved else '안 줄어듦 (수렴 안 함)'}")
+
+    return encoder, decoder
+
+
+if __name__ == "__main__":
+    train()

--- a/train_step1_simple.py
+++ b/train_step1_simple.py
@@ -1,0 +1,203 @@
+"""
+Curriculum Step 1: 50 flights + constraint 고정 + 단순 reward
+reward = -len(pairings) 만 사용 (혜린 복합 reward와 비교용)
+"""
+
+import sys
+import torch
+import torch.optim as optim
+from torch.distributions import Categorical
+
+from model import FlightEncoder, PointerDecoder
+
+sys.path.insert(0, "RL")
+from loader import load_flights
+from environment import get_mask, init_state
+
+
+def flights_to_tensors(flights):
+    origins = torch.tensor([f["origin"] for f in flights])
+    dests = torch.tensor([f["dest"] for f in flights])
+    dep_times = torch.tensor([f["dep_time"] for f in flights], dtype=torch.float32)
+    arr_times = torch.tensor([f["arr_time"] for f in flights], dtype=torch.float32)
+    return origins, dests, dep_times, arr_times
+
+
+def state_to_vec(state, encoder):
+    airport_emb = encoder.airport_emb(torch.tensor(state["current_airport"]))
+    return torch.cat([
+        airport_emb,
+        torch.tensor([state["current_time"]], dtype=torch.float32),
+        torch.tensor([state["duty_time"]], dtype=torch.float32),
+    ])
+
+
+def simple_step(state, action, flights, assigned):
+    """단순 step: reward 없이 state만 업데이트"""
+    f = flights[action]
+    assigned[f["id"]] = True
+    flight_time = f["arr_time"] - f["dep_time"]
+    next_state = {
+        "current_airport": f["dest"],
+        "current_time": f["arr_time"],
+        "duty_time": state["duty_time"] + flight_time,
+        "remaining": state["remaining"] - 1,
+    }
+    return next_state
+
+
+def run_episode(flights, constraint, encoder, decoder, encoded, greedy=False):
+    assigned = {f["id"]: False for f in flights}
+    state = init_state(flights)
+
+    log_probs = []
+    entropies = []
+    n_pairings = 0
+
+    while True:
+        mask_list = get_mask(state, flights, assigned, constraint)
+        mask = torch.tensor(mask_list, dtype=torch.float32)
+
+        if sum(mask_list[:-1]) == 0:
+            n_pairings += 1
+
+            unassigned = [f for f in flights if not assigned[f["id"]]]
+            if len(unassigned) == 0:
+                break
+
+            start = unassigned[0]
+            assigned[start["id"]] = True
+            state = {
+                "current_airport": start["dest"],
+                "current_time": start["arr_time"],
+                "duty_time": start["arr_time"] - start["dep_time"],
+                "remaining": sum(1 for v in assigned.values() if not v),
+            }
+            continue
+
+        state_vec = state_to_vec(state, encoder)
+        probs = decoder(encoded, state_vec, mask)
+
+        if greedy:
+            action = probs.argmax().item()
+        else:
+            dist = Categorical(probs)
+            a = dist.sample()
+            log_probs.append(dist.log_prob(a))
+            entropies.append(dist.entropy())
+            action = a.item()
+
+        if action == len(flights):
+            n_pairings += 1
+
+            unassigned = [f for f in flights if not assigned[f["id"]]]
+            if len(unassigned) == 0:
+                break
+
+            start = unassigned[0]
+            assigned[start["id"]] = True
+            state = {
+                "current_airport": start["dest"],
+                "current_time": start["arr_time"],
+                "duty_time": start["arr_time"] - start["dep_time"],
+                "remaining": sum(1 for v in assigned.values() if not v),
+            }
+            continue
+
+        state = simple_step(state, action, flights, assigned)
+
+    # 단순 reward: -len(pairings)
+    reward = -n_pairings
+    return reward, log_probs, entropies, n_pairings
+
+
+def train():
+    flights = load_flights("RL/data/T_ONTIME_MARKETING.csv", limit=50)
+    n_airports = max(max(f["origin"], f["dest"]) for f in flights) + 1
+
+    CONSTRAINT = {"max_duty": 10.0}
+    c_tensor = torch.tensor([CONSTRAINT["max_duty"]], dtype=torch.float32)
+
+    print(f"=== Step 1 — 단순 reward: -len(pairings) ===")
+    print(f"flights: {len(flights)}개, airports: {n_airports}개")
+    print(f"constraint: max_duty={CONSTRAINT['max_duty']}h (고정)")
+    print()
+
+    encoder = FlightEncoder(n_airports=n_airports)
+    decoder = PointerDecoder()
+
+    params = list(encoder.parameters()) + list(decoder.parameters())
+    optimizer = optim.Adam(params, lr=1e-4)
+
+    origins, dests, dep_times, arr_times = flights_to_tensors(flights)
+
+    greedy_pairings = []
+
+    for episode in range(1000):
+        encoded = encoder(origins, dests, dep_times, arr_times, c_tensor)
+
+        reward_s, log_probs, entropies, pairings_s = run_episode(
+            flights, CONSTRAINT, encoder, decoder, encoded, greedy=False
+        )
+
+        if len(log_probs) == 0:
+            continue
+
+        with torch.no_grad():
+            encoded_g = encoder(origins, dests, dep_times, arr_times, c_tensor)
+            reward_g, _, _, pairings_g = run_episode(
+                flights, CONSTRAINT, encoder, decoder, encoded_g, greedy=True
+            )
+
+        greedy_pairings.append(pairings_g)
+
+        advantage = (reward_s - reward_g) / 10.0
+
+        loss = torch.stack([
+            -lp * advantage - 0.01 * ent
+            for lp, ent in zip(log_probs, entropies)
+        ]).sum()
+
+        optimizer.zero_grad()
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(params, max_norm=1.0)
+        optimizer.step()
+
+        if episode % 50 == 0:
+            recent_p = greedy_pairings[-50:] if len(greedy_pairings) >= 50 else greedy_pairings
+            avg_p = sum(recent_p) / len(recent_p)
+
+            print(
+                f"Ep {episode:4d} | "
+                f"greedy pairings: {pairings_g:2d} (avg50: {avg_p:5.1f}) | "
+                f"sample pairings: {pairings_s:2d} | "
+                f"adv: {advantage:6.2f}"
+            )
+
+    print()
+    print("=" * 60)
+    print("Step 1 결과 (단순 reward)")
+    print("=" * 60)
+
+    first50 = greedy_pairings[:50]
+    last50 = greedy_pairings[-50:]
+    print(f"  처음 50ep 평균 pairings: {sum(first50)/len(first50):.1f}")
+    print(f"  마지막 50ep 평균 pairings: {sum(last50)/len(last50):.1f}")
+
+    improved = sum(first50)/len(first50) > sum(last50)/len(last50)
+    print(f"  수렴 여부: {'줄어듦 (수렴 중)' if improved else '안 줄어듦 (수렴 안 함)'}")
+
+    print()
+    print("FiLM 검증:")
+    for duty in [6.0, 8.0, 10.0, 12.0, 14.0]:
+        c = torch.tensor([duty], dtype=torch.float32)
+        with torch.no_grad():
+            enc = encoder(origins, dests, dep_times, arr_times, c)
+            _, _, _, n_pair = run_episode(
+                flights, {"max_duty": duty}, encoder, decoder, enc, greedy=True
+            )
+        print(f"  max_duty={duty:4.0f}h → pairings: {n_pair:3d}")
+
+
+if __name__ == "__main__":
+    train()

--- a/train_step2.py
+++ b/train_step2.py
@@ -1,0 +1,193 @@
+"""
+Curriculum Step 2: 300 flights + constraint 고정 (max_duty=10h)
+목표: 스케일업해도 수렴하는지 확인
+"""
+
+import sys
+import random
+import torch
+import torch.optim as optim
+from torch.distributions import Categorical
+
+# 시드 고정 — 매번 같은 결과 나오도록
+SEED = 42
+random.seed(SEED)
+torch.manual_seed(SEED)
+
+from model import FlightEncoder, PointerDecoder
+
+sys.path.insert(0, "RL")
+from loader import load_flights
+from environment import get_mask, step, init_state, final_reward
+
+
+def flights_to_tensors(flights):
+    origins = torch.tensor([f["origin"] for f in flights])
+    dests = torch.tensor([f["dest"] for f in flights])
+    dep_times = torch.tensor([f["dep_time"] for f in flights], dtype=torch.float32)
+    arr_times = torch.tensor([f["arr_time"] for f in flights], dtype=torch.float32)
+    return origins, dests, dep_times, arr_times
+
+
+def state_to_vec(state, encoder):
+    airport_emb = encoder.airport_emb(torch.tensor(state["current_airport"]))
+    return torch.cat([
+        airport_emb,
+        torch.tensor([state["current_time"]], dtype=torch.float32),
+        torch.tensor([state["duty_time"]], dtype=torch.float32),
+    ])
+
+
+def run_episode(flights, constraint, encoder, decoder, encoded, greedy=False):
+    assigned = {f["id"]: False for f in flights}
+    state = init_state(flights)
+
+    log_probs = []
+    entropies = []
+    total_reward = 0
+    n_pairings = 0
+
+    while True:
+        mask_list = get_mask(state, flights, assigned, constraint)
+        mask = torch.tensor(mask_list, dtype=torch.float32)
+
+        if sum(mask_list[:-1]) == 0:
+            n_pairings += 1
+            total_reward += -1.0
+
+            unassigned = [f for f in flights if not assigned[f["id"]]]
+            if len(unassigned) == 0:
+                break
+
+            start = unassigned[0]
+            assigned[start["id"]] = True
+            state = {
+                "current_airport": start["dest"],
+                "current_time": start["arr_time"],
+                "duty_time": start["arr_time"] - start["dep_time"],
+                "remaining": sum(1 for v in assigned.values() if not v),
+            }
+            continue
+
+        state_vec = state_to_vec(state, encoder)
+        probs = decoder(encoded, state_vec, mask)
+
+        if greedy:
+            action = probs.argmax().item()
+        else:
+            dist = Categorical(probs)
+            a = dist.sample()
+            log_probs.append(dist.log_prob(a))
+            entropies.append(dist.entropy())
+            action = a.item()
+
+        if action == len(flights):
+            n_pairings += 1
+            total_reward += -1.0
+
+            unassigned = [f for f in flights if not assigned[f["id"]]]
+            if len(unassigned) == 0:
+                break
+
+            start = unassigned[0]
+            assigned[start["id"]] = True
+            state = {
+                "current_airport": start["dest"],
+                "current_time": start["arr_time"],
+                "duty_time": start["arr_time"] - start["dep_time"],
+                "remaining": sum(1 for v in assigned.values() if not v),
+            }
+            continue
+
+        state, r, done = step(state, action, flights, assigned, constraint)
+        total_reward += r
+
+        if done:
+            break
+
+    total_reward += final_reward(assigned)
+    return total_reward, log_probs, entropies, n_pairings
+
+
+def train():
+    # ★ 300 flights로 스케일업
+    flights = load_flights("RL/data/T_ONTIME_MARKETING.csv", limit=300)
+    n_airports = max(max(f["origin"], f["dest"]) for f in flights) + 1
+
+    CONSTRAINT = {"max_duty": 10.0}
+    c_tensor = torch.tensor([CONSTRAINT["max_duty"]], dtype=torch.float32)
+
+    print(f"=== Curriculum Step 2 ===")
+    print(f"flights: {len(flights)}개, airports: {n_airports}개")
+    print(f"constraint: max_duty={CONSTRAINT['max_duty']}h (고정)")
+    print()
+
+    encoder = FlightEncoder(n_airports=n_airports)
+    decoder = PointerDecoder()
+
+    params = list(encoder.parameters()) + list(decoder.parameters())
+    optimizer = optim.Adam(params, lr=1e-4)
+
+    origins, dests, dep_times, arr_times = flights_to_tensors(flights)
+
+    greedy_rewards = []
+    greedy_pairings = []
+
+    for episode in range(500):
+        encoded = encoder(origins, dests, dep_times, arr_times, c_tensor)
+
+        reward_s, log_probs, entropies, pairings_s = run_episode(
+            flights, CONSTRAINT, encoder, decoder, encoded, greedy=False
+        )
+
+        if len(log_probs) == 0:
+            continue
+
+        with torch.no_grad():
+            encoded_g = encoder(origins, dests, dep_times, arr_times, c_tensor)
+            reward_g, _, _, pairings_g = run_episode(
+                flights, CONSTRAINT, encoder, decoder, encoded_g, greedy=True
+            )
+
+        greedy_rewards.append(reward_g)
+        greedy_pairings.append(pairings_g)
+
+        advantage = (reward_s - reward_g) / 10.0
+
+        loss = torch.stack([
+            -lp * advantage - 0.01 * ent
+            for lp, ent in zip(log_probs, entropies)
+        ]).sum()
+
+        optimizer.zero_grad()
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(params, max_norm=1.0)
+        optimizer.step()
+
+        if episode % 25 == 0:
+            recent_p = greedy_pairings[-25:] if len(greedy_pairings) >= 25 else greedy_pairings
+            avg_p = sum(recent_p) / len(recent_p)
+
+            print(
+                f"Ep {episode:4d} | "
+                f"greedy pairings: {pairings_g:3d} (avg25: {avg_p:6.1f}) | "
+                f"sample pairings: {pairings_s:3d} | "
+                f"adv: {advantage:6.2f}"
+            )
+
+    print()
+    print("=" * 60)
+    print("Step 2 결과")
+    print("=" * 60)
+
+    first50 = greedy_pairings[:50]
+    last50 = greedy_pairings[-50:]
+    print(f"  처음 50ep 평균 pairings: {sum(first50)/len(first50):.1f}")
+    print(f"  마지막 50ep 평균 pairings: {sum(last50)/len(last50):.1f}")
+
+    improved = sum(first50)/len(first50) > sum(last50)/len(last50)
+    print(f"  수렴 여부: {'줄어듦 (수렴 중)' if improved else '안 줄어듦 (수렴 안 함)'}")
+
+
+if __name__ == "__main__":
+    train()


### PR DESCRIPTION
  - environment.py mask 보강 (공항 + 시간 + duty 체크 추가)                     
  - train.py: 찬주 model(encoder/decoder) + 혜린 env(mask/step/reward) 통합     
  - Curriculum Step 1 (50 flights): 수렴 확인                                   
  - Curriculum Step 2 (300 flights): 수렴 확인 (seed=42 고정)
  - Curriculum Step 3 (FiLM 검증): constraint별 pairing 차이 확인               
  - Reward 비교 실험: 복합 vs 단순 (-pairings)                     
  
-> 자세한 사항은 노션 [찬주] 0403에 정리해뒀어용