### PR TITLE
[Feat] ENV - environment 섹션 구조 개선 및 config 분리

### DIFF
--- a/RL/airline_constraints/delta.py
+++ b/RL/airline_constraints/delta.py
@@ -1,0 +1,14 @@
+# Delta 항공사 운항 제약값
+# TODO: base_airport = 0 하드코딩 → loader.py Global Airport Index 확정 후 ATL 실제 ID로 교체
+# 현재 per-airline 고정 방식 → multi-airline 확장 시 unified index 전환 여부 혜린과 합의 필요
+
+DELTA_CONSTRAINTS = {
+    "max_duty":        13.0,  # duty 최대 경과 시간 (h), FAA Part 117 테이블 최댓값
+    "min_conn":         0.5,  # 최소 연결 시간 (h, 30분)
+    "max_conn":         8.0,  # 최대 연결 시간 (h)
+    "max_legs":           4,  # duty당 최대 flight 수
+    "base_airport":       0,  # base 공항 ID (FiLM 입력 제외, 마스킹 전용)
+    "min_rest":         9.5,  # duty 간 최소 휴식 (h), FAA Part 117 기준
+    "max_duty_periods":   4,  # pairing당 최대 duty 수
+    "max_pairing_days":   5,  # pairing 최대 기간 (일)
+}

--- a/RL/airline_constraints/delta.py
+++ b/RL/airline_constraints/delta.py
@@ -7,8 +7,8 @@ DELTA_CONSTRAINTS = {
     "min_conn":         0.5,  # 최소 연결 시간 (h, 30분)
     "max_conn":         8.0,  # 최대 연결 시간 (h)
     "max_legs":           4,  # duty당 최대 flight 수
-    "base_airport":       0,  # base 공항 ID (FiLM 입력 제외, 마스킹 전용)
     "min_rest":         9.5,  # duty 간 최소 휴식 (h), FAA Part 117 기준
     "max_duty_periods":   4,  # pairing당 최대 duty 수
     "max_pairing_days":   5,  # pairing 최대 기간 (일)
+    # base_airport 제외 — get_delta_constraints(base_airport) 호출 시 에피소드별 주입
 }

--- a/RL/config.py
+++ b/RL/config.py
@@ -19,6 +19,7 @@ DEFAULT_CONSTRAINTS = {
     "max_pairing_days":    5,   # pairing 최대 기간 (일)
     "pairing_cost":      5.0,   # END_PAIRING reward 패널티
     "uncovered_penalty": 10.0,  # 미배정 flight 1개당 패널티
+    "base_penalty":      5.0,   # END_PAIRING 시 base 미복귀 패널티
 }
 
 # 커리큘럼 스테이지별 허용 규칙

--- a/RL/config.py
+++ b/RL/config.py
@@ -1,0 +1,32 @@
+# Action 인덱스 (numpy 음수 인덱싱 활용 — mask[-2], mask[-1])
+END_DUTY    = -2
+END_PAIRING = -1
+
+# FAA Part 117 — duty 내 leg 수 기준 최대 flight duty period (hours)
+# 추후 항공사 확장 시 다른 규정 테이블로 교체 가능
+FAA_DUTY_TABLE = {1: 13.0, 2: 13.0, 3: 12.0, 4: 11.5, 5: 11.0, 6: 10.5}
+
+# Delta 기본 제약 — FiLM constraint vector(7,) 및 마스킹 기본값
+# TODO: base_airport = 0 하드코딩 → loader.py Global Airport Index 확정 후 ATL 실제 ID로 교체
+DEFAULT_CONSTRAINTS = {
+    "max_duty":         13.0,   # duty 최대 경과 시간 (h)
+    "min_conn":          0.5,   # 최소 연결 시간 (h, 30분)
+    "max_conn":          8.0,   # 최대 연결 시간 (h)
+    "max_legs":            4,   # duty당 최대 flight 수
+    "base_airport":        0,   # base 공항 ID (Global Index 확정 전 임시값)
+    "min_rest":          9.5,   # duty 간 최소 휴식 (h)
+    "max_duty_periods":    4,   # pairing당 최대 duty 수
+    "max_pairing_days":    5,   # pairing 최대 기간 (일)
+    "pairing_cost":      5.0,   # END_PAIRING reward 패널티
+    "uncovered_penalty": 10.0,  # 미배정 flight 1개당 패널티
+}
+
+# 커리큘럼 스테이지별 허용 규칙
+# Stage 1: 단일 duty (END_DUTY 불가) — 기본 연결 패턴 학습
+# Stage 2: multi-day (END_DUTY 가능) — overnight + base 복귀 학습
+# Stage 3: Stage 2 + constraint 랜덤화 — FiLM 적응 학습
+CURRICULUM_CONFIG = {
+    1: {"allow_end_duty": False},
+    2: {"allow_end_duty": True},
+    3: {"allow_end_duty": True},
+}

--- a/RL/constraints.py
+++ b/RL/constraints.py
@@ -16,13 +16,16 @@ from airline_constraints.delta import DELTA_CONSTRAINTS
 # from airline_constraints.ua import TURKISH_CONSTRAINTS  # 이런식으로 추후 추가
 
 
-def get_delta_constraints():
+def get_delta_constraints(base_airport: int):
     """Delta 항공사 constraint dict 반환
 
+    base_airport: 에피소드별 base 공항 ID
+    # TODO: loader.py [Base Input] 단계에서 사용자가 입력한 base를 train.py가 받아서 여기에 주입하는 구조
+    # loader.py가 선택된 base를 train.py에 어떻게 넘겨주는지 혜린 PR 확인 후 train.py 호출 위치 확정 필요
     FiLM constraint vector(7,) 입력 및 environment.py 마스킹에 사용.
-    base_airport는 FiLM 입력에서 제외 (카테고리형 → FILM_CONSTRAINT_KEYS에 없음).
+    base_airport는 FiLM 입력에서 제외 (카테고리형 → FILM_CONSTRAINT_KEYS에 없음)
     """
-    return DELTA_CONSTRAINTS
+    return {**DELTA_CONSTRAINTS, "base_airport": base_airport}
 
 
 # FiLM 입력 constraint 키 순서 — constraint_to_tensor()가 이 순서대로 tensor 변환 → shape (7,)

--- a/RL/constraints.py
+++ b/RL/constraints.py
@@ -1,26 +1,38 @@
+# constraints.py — 항공사별 운항 제약 정의
+#
+# 역할:
+#   - get_<airline>_constraints(): 항공사별 constraint dict 반환 → environment.py 마스킹 + FiLM 입력에 사용
+#   - FILM_CONSTRAINT_KEYS: constraint dict 중 FiLM에 넣을 7개 키 순서 정의
+#
+# config.py와의 관계:
+#   - config.DEFAULT_CONSTRAINTS: constraint가 없을 때 environment.py가 쓰는 fallback (+ reward 상수 포함)
+#   - constraints.py: 항공사별 실제 값의 출처 (train.py가 이걸 읽어서 environment에 넘기도록)
+#   - reward 상수(pairing_cost, uncovered_penalty)는 config.py에서만 관리 — 여기에 넣지 않음
+
+
+# 항공사별 constraint 값은 airline_constraints/ 에서 관리
+# 새 항공사 추가 시 airline_constraints/<airline>.py 파일 추가 후 아래에 get 함수 작성
+from airline_constraints.delta import DELTA_CONSTRAINTS
+# from airline_constraints.ua import TURKISH_CONSTRAINTS  # 이런식으로 추후 추가
+
+
 def get_delta_constraints():
-    return {
-        # 현재 적용 (5개)
-        "max_duty":         13.0,   # duty 최대 경과 시간 (시간, FAA Part 117 테이블 최댓값)
-        "min_conn":          0.5,   # 최소 연결 시간 (30분)
-        "max_conn":          8.0,   # 최대 연결 시간 (8시간)
-        "max_legs":          4,     # duty당 최대 flights
-        "base_airport":      0,     # base 공항 ID (FiLM 제외)
+    """Delta 항공사 constraint dict 반환
 
-        # multi-day (FAA Part 117 기반)
-        "min_rest":          9.5,   # duty 간 최소 휴식 (시간)
-        "max_duty_periods":  4,     # pairing당 최대 duty 횟수
-        "max_pairing_days":  5,     # pairing 최대 기간 (일)
-    }
+    FiLM constraint vector(7,) 입력 및 environment.py 마스킹에 사용.
+    base_airport는 FiLM 입력에서 제외 (카테고리형 → FILM_CONSTRAINT_KEYS에 없음).
+    """
+    return DELTA_CONSTRAINTS
 
 
-# FiLM 입력 constraint key (base_airport는 카테고리이므로 제외)
+# FiLM 입력 constraint 키 순서 — constraint_to_tensor()가 이 순서대로 tensor 변환 → shape (7,)
+# base_airport는 카테고리형이라 제외
 FILM_CONSTRAINT_KEYS = [
-    "max_duty",
-    "min_conn",
-    "max_conn",
-    "max_legs",
-    "min_rest",
-    "max_duty_periods",
-    "max_pairing_days",
+    "max_duty",         # 0
+    "min_conn",         # 1
+    "max_conn",         # 2
+    "max_legs",         # 3
+    "min_rest",         # 4
+    "max_duty_periods", # 5
+    "max_pairing_days", # 6
 ]

--- a/RL/constraints.py
+++ b/RL/constraints.py
@@ -20,8 +20,8 @@ def get_delta_constraints(base_airport: int):
     """Delta 항공사 constraint dict 반환
 
     base_airport: 에피소드별 base 공항 ID
-    # TODO: loader.py [Base Input] 단계에서 사용자가 입력한 base를 train.py가 받아서 여기에 주입하는 구조
-    # loader.py가 선택된 base를 train.py에 어떻게 넘겨주는지 혜린 PR 확인 후 train.py 호출 위치 확정 필요
+    - bases_to_ids(["ATL", "DTW", ...], airport_map) → 정수 ID 리스트 반환
+    - train.py에서 그 중 하나 랜덤 선택하고 여기에 주입하는 구조
     FiLM constraint vector(7,) 입력 및 environment.py 마스킹에 사용.
     base_airport는 FiLM 입력에서 제외 (카테고리형 → FILM_CONSTRAINT_KEYS에 없음)
     """

--- a/RL/environment.py
+++ b/RL/environment.py
@@ -44,7 +44,11 @@ def get_mask(state, flights, assigned, constraint=None, stage=3):
         valid = True
 
         # 1. 공항 연결 검사
-        if not pairing_start and f["origin"] != state["current_airport"]:
+        # pairing 첫 leg base 출발 강제 (hub_only 제거로 전체 편이 후보에 포함되니까 명시적 체크)
+        if pairing_start:
+            if f["origin"] != c.get("base_airport", config.DEFAULT_CONSTRAINTS["base_airport"]):
+                valid = False
+        elif f["origin"] != state["current_airport"]:
             valid = False
 
         # 2. 시간 연결 검사
@@ -93,10 +97,10 @@ def get_mask(state, flights, assigned, constraint=None, stage=3):
     # END_PAIRING (mask[-1] = mask[N+1])
     pairing_elapsed_days = (state["current_time"] - pairing_start_time) / 24.0
     can_end_pairing = (
-        state["current_airport"] == c.get("base_airport", config.DEFAULT_CONSTRAINTS["base_airport"])
-        and state.get("legs", 0) > 0
+        state.get("legs", 0) > 0
         and pairing_elapsed_days <= c.get("max_pairing_days", config.DEFAULT_CONSTRAINTS["max_pairing_days"])
     )
+    # base 미복귀 시 BASE_PENALTY는 step()에서 reward로 처리 (hard mask 제거 → soft penalty)
     if can_end_pairing:
         mask[config.END_PAIRING] = 1
 
@@ -133,15 +137,22 @@ def step(state, action, flights, assigned, constraint=None):
     # END_PAIRING → pairing 비용 부과 후 새 pairing 시작 (또는 에피소드 종료)
     if action == N + 1:
         p_cost = c.get("pairing_cost", config.DEFAULT_CONSTRAINTS["pairing_cost"])
+        base_penalty = c.get("base_penalty", config.DEFAULT_CONSTRAINTS["base_penalty"])
+        # constraint["base_airport"] 에피소드별 주입
+        base = c.get("base_airport", config.DEFAULT_CONSTRAINTS["base_airport"])
+        reward = -p_cost
+        if state["current_airport"] != base:
+            reward -= base_penalty
         unassigned = [f for f in flights if not assigned[f["id"]]]
         if not unassigned:
             # 모든 flight 커버 완료 → 에피소드 종료
-            return state, -p_cost, True
-        # 미배정 flight 남아있음 → 새 pairing 시작
-        next_time = min(f["dep_time"] for f in unassigned)
+            return state, reward, True
+        # 미배정 flight 남아있음 → 새 pairing 시작 (base 출발 편 중 가장 이른 편 기준)
+        base_unassigned = [f for f in unassigned if f["origin"] == base]
+        next_time = min(f["dep_time"] for f in base_unassigned) if base_unassigned else min(f["dep_time"] for f in unassigned)
         next_state = {
             **state,
-            "current_airport":    c.get("base_airport", config.DEFAULT_CONSTRAINTS["base_airport"]),
+            "current_airport":    base,
             "current_time":       next_time,
             "duty_time":          0.0,
             "duty_start_time":    next_time,
@@ -152,7 +163,7 @@ def step(state, action, flights, assigned, constraint=None):
             "pairing_start":      True,
             "pairing_start_time": next_time,
         }
-        return next_state, -p_cost, False
+        return next_state, reward, False
 
     # Flight 선택
     f = flights[action]

--- a/RL/environment.py
+++ b/RL/environment.py
@@ -1,115 +1,185 @@
-END_DUTY = -2     # 현재 duty 종료 → rest period 진입, pairing 계속
-END_PAIRING = -1  # pairing 전체 종료
+import numpy as np
+import config
+
+# TODO: 혜린 loader.py 확인
+# flight dict 키 이름 ("origin", "dest", "dep_time", "arr_time", "id") 변경 여부
+# environment.py 전체에서 이 키를 직접 참조하므로 이름 바뀌면 같이 수정 필요
 
 
-def get_max_duty(legs_after, constraint):
-    """FAA Part 117 — duty에 추가될 leg 수 기준 max flight duty period (hours)"""
-    table = {1: 13.0, 2: 13.0, 3: 12.0, 4: 11.5, 5: 11.0, 6: 10.5}
-    return table.get(min(legs_after, 6), 10.0)
+def get_max_duty(legs_count, custom_max_duty=None):
+    """FAA Part 117과 항공사 정책 중 더 엄격한 duty 시간 한도 반환
 
-
-def get_mask(state, flights, assigned, constraint):
+    legs_count: 해당 duty에 추가될 leg 수 (현재 legs + 1)
+    custom_max_duty: constraint["max_duty"] 값. None이면 DEFAULT_CONSTRAINTS 사용
     """
-    반환: [flight_0, ..., flight_N-1, END_DUTY, END_PAIRING]
-    인덱스: 0..N-1 = flight, N = END_DUTY, N+1 = END_PAIRING
+    faa_limit = config.FAA_DUTY_TABLE.get(min(legs_count, 6), 10.0)
+    if custom_max_duty is not None:
+        return min(faa_limit, custom_max_duty)
+    return min(faa_limit, config.DEFAULT_CONSTRAINTS["max_duty"])
+
+
+def get_mask(state, flights, assigned, constraint=None, stage=3):
+    """현재 state에서 선택 가능한 action 마스크 반환
+
+    반환: 크기 [N + 2]의 list (0: 불가, 1: 가능)
+         index 0..N-1 = flight, N = END_DUTY, N+1 = END_PAIRING
     """
-    mask = []
-    pairing_start = state.get("pairing_start", False)
-    is_resting = state.get("is_resting", False)
-    rest_end = state.get("rest_end_time")
-    duty_period = state.get("duty_period", 0)
-    max_duty_periods = constraint.get("max_duty_periods", 4)
-    max_pairing_days = constraint.get("max_pairing_days", 5)
+    c = constraint if constraint else config.DEFAULT_CONSTRAINTS
+    stage_rule = config.CURRICULUM_CONFIG.get(stage, config.CURRICULUM_CONFIG[3])
+
+    N = len(flights)
+    mask = np.zeros(N + 2, dtype=np.int32)
+
+    pairing_start    = state.get("pairing_start", False)
+    is_resting       = state.get("is_resting", False)
+    rest_end         = state.get("rest_end_time", 0.0)
+    duty_period      = state.get("duty_period", 0)
+    duty_start_time  = state.get("duty_start_time", state["current_time"])
     pairing_start_time = state.get("pairing_start_time", state["current_time"])
 
-    for f in flights:
+    for i, f in enumerate(flights):
         if assigned[f["id"]]:
-            mask.append(0)
             continue
-
-        flight_time = f["arr_time"] - f["dep_time"]
-        gap = f["dep_time"] - state["current_time"]
 
         valid = True
 
-        # rest 중이면 rest_end_time 이후 출발 flight만 허용
-        if is_resting:
-            if rest_end is not None and f["dep_time"] < rest_end:
-                valid = False
-
-        legs_after = state.get("legs", 0) + 1
-        effective_max_duty = min(get_max_duty(legs_after, constraint), constraint.get("max_duty", 13.0))
-
-        if pairing_start:
-            if state.get("duty_time", 0.0) + flight_time > effective_max_duty:
-                valid = False
-            if legs_after > constraint.get("max_legs", 999):
-                valid = False
-        else:
-            if not is_resting:
-                if f["origin"] != state["current_airport"]:
-                    valid = False
-                if gap < constraint["min_conn"] or gap > constraint["max_conn"]:
-                    valid = False
-                if state["duty_time"] + flight_time > effective_max_duty:
-                    valid = False
-                if legs_after > constraint.get("max_legs", 999):
-                    valid = False
-            else:
-                # rest 종료 후 새 duty 시작: 공항 연결 체크, connection 제약은 없음
-                if f["origin"] != state["current_airport"]:
-                    valid = False
-
-        # pairing 기간 초과 방지
-        elapsed_days = (f["dep_time"] - pairing_start_time) / 24.0
-        if elapsed_days > max_pairing_days:
+        # 1. 공항 연결 검사
+        if not pairing_start and f["origin"] != state["current_airport"]:
             valid = False
 
-        mask.append(1 if valid else 0)
+        # 2. 시간 연결 검사
+        if is_resting:
+            # rest 미종료 시 탑승 불가
+            if f["dep_time"] < rest_end:
+                valid = False
+        else:
+            if not pairing_start:
+                gap = f["dep_time"] - state["current_time"]
+                if gap < c.get("min_conn", config.DEFAULT_CONSTRAINTS["min_conn"]) or \
+                   gap > c.get("max_conn", config.DEFAULT_CONSTRAINTS["max_conn"]):
+                    valid = False
 
-    # END_DUTY: 현재 duty에 leg가 있고, 추가 duty period 여유가 있고, rest 중 아닐 때
+        # 3. Duty 시간 제약 (FAA Part 117)
+        # duty window = duty 시작 ~ 해당 flight 도착까지 전체 경과 시간
+        # pairing 첫 편이거나 rest 직후 새 duty 시작이면 기준점을 해당 편 출발로 리셋
+        legs_after = state.get("legs", 0) + 1
+        effective_max_duty = get_max_duty(legs_after, c.get("max_duty"))
+        current_duty_start = f["dep_time"] if (pairing_start or is_resting) else duty_start_time
+        total_duty_window = f["arr_time"] - current_duty_start
+        if total_duty_window > effective_max_duty:
+            valid = False
+        if legs_after > c.get("max_legs", config.DEFAULT_CONSTRAINTS["max_legs"]):
+            valid = False
+
+        # 4. Pairing 기간 제약
+        elapsed_days = (f["arr_time"] - pairing_start_time) / 24.0
+        if elapsed_days > c.get("max_pairing_days", config.DEFAULT_CONSTRAINTS["max_pairing_days"]):
+            valid = False
+
+        if valid:
+            mask[i] = 1
+
+    # END_DUTY (mask[-2] = mask[N])
     can_end_duty = (
-        state.get("legs", 0) > 0
+        stage_rule["allow_end_duty"]
+        and state.get("legs", 0) > 0
         and not is_resting
         and not pairing_start
-        and duty_period < max_duty_periods - 1
+        and duty_period < c.get("max_duty_periods", config.DEFAULT_CONSTRAINTS["max_duty_periods"]) - 1
     )
-    mask.append(1 if can_end_duty else 0)
+    if can_end_duty:
+        mask[config.END_DUTY] = 1
 
-    # END_PAIRING: base에 있고 leg가 있고 pairing 기간 내
+    # END_PAIRING (mask[-1] = mask[N+1])
     pairing_elapsed_days = (state["current_time"] - pairing_start_time) / 24.0
     can_end_pairing = (
-        state["current_airport"] == constraint["base_airport"]
+        state["current_airport"] == c.get("base_airport", config.DEFAULT_CONSTRAINTS["base_airport"])
         and state.get("legs", 0) > 0
-        and pairing_elapsed_days <= max_pairing_days
+        and pairing_elapsed_days <= c.get("max_pairing_days", config.DEFAULT_CONSTRAINTS["max_pairing_days"])
     )
-    mask.append(1 if can_end_pairing else 0)
+    if can_end_pairing:
+        mask[config.END_PAIRING] = 1
 
-    return mask
+    return mask.tolist()
 
 
-def step(state, action, flights, assigned, constraint):
+def step(state, action, flights, assigned, constraint=None):
+    """action을 받아 next_state, reward, done 반환
+
+    action 범위:
+      0 .. N-1  : flight 선택
+      N         : END_DUTY
+      N+1       : END_PAIRING
+    done=True 조건: END_PAIRING 선택 시 모든 flight가 커버된 경우
+    """
+    c = constraint if constraint else config.DEFAULT_CONSTRAINTS
+    N = len(flights)
+
+    # END_DUTY → rest 진입, pairing 계속
+    if action == N:
+        min_rest = c.get("min_rest", config.DEFAULT_CONSTRAINTS["min_rest"])
+        next_state = {
+            **state,
+            "duty_time":       0.0,
+            "duty_start_time": state["current_time"] + min_rest,
+            "legs":            0,
+            "is_resting":      True,
+            "rest_end_time":   state["current_time"] + min_rest,
+            "duty_period":     state.get("duty_period", 0) + 1,
+            "pairing_start":   False,
+        }
+        return next_state, 0.0, False
+
+    # END_PAIRING → pairing 비용 부과 후 새 pairing 시작 (또는 에피소드 종료)
+    if action == N + 1:
+        p_cost = c.get("pairing_cost", config.DEFAULT_CONSTRAINTS["pairing_cost"])
+        unassigned = [f for f in flights if not assigned[f["id"]]]
+        if not unassigned:
+            # 모든 flight 커버 완료 → 에피소드 종료
+            return state, -p_cost, True
+        # 미배정 flight 남아있음 → 새 pairing 시작
+        next_time = min(f["dep_time"] for f in unassigned)
+        next_state = {
+            **state,
+            "current_airport":    c.get("base_airport", config.DEFAULT_CONSTRAINTS["base_airport"]),
+            "current_time":       next_time,
+            "duty_time":          0.0,
+            "duty_start_time":    next_time,
+            "legs":               0,
+            "duty_period":        0,
+            "is_resting":         False,
+            "rest_end_time":      None,
+            "pairing_start":      True,
+            "pairing_start_time": next_time,
+        }
+        return next_state, -p_cost, False
+
+    # Flight 선택
     f = flights[action]
     assigned[f["id"]] = True
-
     flight_time = f["arr_time"] - f["dep_time"]
+
+    # pairing 첫 편이면 pairing_start_time 리셋, rest 직후 새 duty면 duty_start_time 리셋
+    p_start_time = f["dep_time"] if state.get("pairing_start", False) else state["pairing_start_time"]
+    d_start_time = f["dep_time"] if (state.get("pairing_start", False) or state.get("is_resting", False)) \
+                   else state["duty_start_time"]
 
     next_state = {
         "current_airport":    f["dest"],
         "current_time":       f["arr_time"],
-        "duty_time":          state["duty_time"] + flight_time,
-        "duty_start_time":    state["duty_start_time"],
+        "duty_time":          (0.0 if state.get("is_resting", False) else state["duty_time"]) + flight_time,
+        "duty_start_time":    d_start_time,
         "legs":               state.get("legs", 0) + 1,
         "remaining":          state["remaining"] - 1,
         "pairing_start":      False,
-        # multi-day 필드 전파
         "duty_period":        state.get("duty_period", 0),
-        "pairing_start_time": state.get("pairing_start_time", state["current_time"]),
+        "pairing_start_time": p_start_time,
         "is_resting":         False,
         "rest_end_time":      None,
     }
 
-    # dead time: duty 내 flight 간 연결 대기 시간 (pairing 첫 flight나 rest 직후는 제외)
+    # dead time reward: duty 중간 flight 간 대기 시간만 패널티
+    # pairing 첫 편이거나 rest 직후 첫 편은 대기 시간 없으므로 제외
     if not state.get("pairing_start", False) and not state.get("is_resting", False):
         reward = -(f["dep_time"] - state["current_time"])
     else:
@@ -118,21 +188,8 @@ def step(state, action, flights, assigned, constraint):
     return next_state, reward, False
 
 
-def step_end_duty(state, constraint):
-    """현재 duty 종료 → rest period 진입, pairing은 계속"""
-    min_rest = constraint.get("min_rest", 9.5)
-    return {
-        **state,
-        "duty_time":       0.0,
-        "duty_start_time": state["current_time"] + min_rest,
-        "legs":            0,
-        "is_resting":      True,
-        "rest_end_time":   state["current_time"] + min_rest,
-        "duty_period":     state.get("duty_period", 0) + 1,
-        "pairing_start":   False,
-    }
-
-
-def final_reward(assigned, uncovered_penalty=10.0):
+def final_reward(assigned, custom_penalty=None):
+    """에피소드 종료 시 미배정 flight에 대한 패널티 반환"""
+    penalty = custom_penalty if custom_penalty is not None else config.DEFAULT_CONSTRAINTS["uncovered_penalty"]
     remaining = sum(1 for v in assigned.values() if not v)
-    return -uncovered_penalty * remaining
+    return -penalty * remaining

--- a/RL/environment.py
+++ b/RL/environment.py
@@ -1,9 +1,7 @@
 import numpy as np
 import config
 
-# TODO: 혜린 loader.py 확인
-# flight dict 키 이름 ("origin", "dest", "dep_time", "arr_time", "id") 변경 여부
-# environment.py 전체에서 이 키를 직접 참조하므로 이름 바뀌면 같이 수정 필요
+# flight dict 키: "origin", "dest", "dep_time", "arr_time", "id" 
 
 
 def get_max_duty(legs_count, custom_max_duty=None):

--- a/RL/state.py
+++ b/RL/state.py
@@ -2,13 +2,17 @@ def init_state(flights, constraint):
     """에피소드 초기 state 생성
 
     flights: loader.py가 반환한 flight dict 리스트 (dep_time 기준 오름차순 정렬)
-    constraint: 미사용 — 시그니처 통일 목적으로만 받음. 실제 제약 적용은 environment.py에서 수행.
+    constraint: 에피소드별 constraint dict — base_airport 등 초기화에 사용
     """
-    first = flights[0]
+    base = constraint["base_airport"]
+    base_flights = [f for f in flights if f["origin"] == base]
+    # base 출발 편이 없으면 flights[0] fallback
+    # TODO: loader.py가 base 출발 편 포함된 window만 보장해주면 이 분기 불필요함! - 추후 혜린 PR 확인 필요
+    first = min(base_flights, key=lambda f: f["dep_time"]) if base_flights else flights[0]
 
     return {
         # 현재 위치 / 시각
-        "current_airport":    first["origin"],       # 현재 승무원 위치 공항 ID
+        "current_airport":    base,                   # 현재 승무원 위치 공항 ID (에피소드 base)
         "current_time":       first["dep_time"],      # 현재 시각 (절대시간, hours)
 
         # duty 내부 추적

--- a/RL/state.py
+++ b/RL/state.py
@@ -7,7 +7,8 @@ def init_state(flights, constraint):
     base = constraint["base_airport"]
     base_flights = [f for f in flights if f["origin"] == base]
     # base 출발 편이 없으면 flights[0] fallback
-    # TODO: loader.py가 base 출발 편 포함된 window만 보장해주면 이 분기 불필요함! - 추후 혜린 PR 확인 필요
+    # load_flights_rolling()은 전체 편 포함 → base 출발 편 미보장
+    # fallback 유지 / base 출발 편 없는 window는 train.py에서 에피소드 스킵 처리 필요
     first = min(base_flights, key=lambda f: f["dep_time"]) if base_flights else flights[0]
 
     return {

--- a/RL/state.py
+++ b/RL/state.py
@@ -1,17 +1,32 @@
 def init_state(flights, constraint):
+    """에피소드 초기 state 생성
+
+    flights: loader.py가 반환한 flight dict 리스트 (dep_time 기준 오름차순 정렬)
+    constraint: 미사용 — 시그니처 통일 목적으로만 받음. 실제 제약 적용은 environment.py에서 수행.
+    """
     first = flights[0]
 
     return {
-        "current_airport":    first["origin"],
-        "current_time":       first["dep_time"],
+        # 현재 위치 / 시각
+        "current_airport":    first["origin"],       # 현재 승무원 위치 공항 ID
+        "current_time":       first["dep_time"],      # 현재 시각 (절대시간, hours)
+
+        # duty 내부 추적
+        # duty_time: decoder 입력 feature용 누적 비행 시간 (h)
+        # FAA duty window 한도 체크는 duty_start_time 기준으로 get_mask()에서 별도 계산
         "duty_time":          0.0,
-        "duty_start_time":    first["dep_time"],
-        "legs":               0,
-        "remaining":          len(flights),
-        "pairing_start":      True,
-        # multi-day 필드
-        "duty_period":        0,
-        "pairing_start_time": first["dep_time"],
-        "is_resting":         False,
-        "rest_end_time":      None,
+        "duty_start_time":    first["dep_time"],      # 현재 duty 시작 시각 (FAA window 기준점)
+        "legs":               0,                      # 현재 duty 내 선택된 flight 수
+
+        # 에피소드 전체 추적
+        "remaining":          len(flights),           # 미배정 flight 수
+
+        # pairing 상태
+        "pairing_start":      True,                   # 새 pairing 시작 직후 — True면 공항/시간 체크 스킵
+        "duty_period":        0,                      # 현재 pairing 내 완료된 duty 수
+        "pairing_start_time": first["dep_time"],      # pairing 전체 기간 계산 기준점
+
+        # rest 상태
+        "is_resting":         False,                  # END_DUTY 후 rest 중 여부
+        "rest_end_time":      None,                   # rest 종료 시각 (is_resting=True일 때 유효)
     }


### PR DESCRIPTION
  ## 개요
  RL 환경(environment.py, state.py, constraints.py)을 파이프라인 설계에 맞게 수정하고, 하드코딩된 상수를 분리했습니다.

  ---

  ## 파일별 변경 내용

  ### RL/config.py (new)
  **역할: 환경 전반에서 쓰이는 상수 한 곳에서 관리**

기존에는 END_DUTY, END_PAIRING 같은 action 인덱스나 FAA_DUTY_TABLE이 environment.py 안에 하드코딩되어 있었습니다. 나중에 항공사 확장하거나 커리큘럼 수정할 때 값 찾으러 코드 내부 들어가야 하는 문제가 있어서 분리했습니다.

  - `END_DUTY = -2`, `END_PAIRING = -1`: numpy 음수 인덱싱 활용
  - `FAA_DUTY_TABLE`: legs 수 기준 최대 duty 시간 테이블
  - `DEFAULT_CONSTRAINTS`: constraint 없을 때 environment 내부 fallback값
  - `CURRICULUM_CONFIG`: 스테이지별 END_DUTY 허용 여부 스위치
    (Stage 1은 단일 duty만 → END_DUTY 차단)

  ---

  ### RL/environment.py (수정)
  **역할: RL MDP의 전환 로직 — mask → action → next state + reward**

  1. **step() 통합**
     기존에 step_end_duty(), step_end_pairing()이 별도 함수로 있어서 train.py에서 action 종류별로 다른 함수를 호출해야 했습니다. step() 하나로 통합해서 train.py가 항상 step()만 호출하면 됩니다.
     - action 0~N-1: flight 선택 → 공항/시간 갱신, dead_time reward
     - action N (END_DUTY): rest 진입, duty 리셋
     - action N+1 (END_PAIRING): pairing 비용 부과 후 새 pairing 시작.
       미배정 flight 없으면 done=True로 에피소드 종료

  2. **duty 시간 계산 방식 변경**
     기존은 순수 비행 시간만 누적했는데, FAA Part 117의 duty period는 연결 대기 시간도 포함입니다. duty 시작 시각 ~ 해당 flight 도착 시각 전체 window로 계산하도록 수정했습니다.

  3. **get_mask()에 stage 파라미터 추가**
     커리큘럼 Stage 1은 단일 duty만 학습해야 하므로 END_DUTY 마스크를 stage별로 자동 제어합니다.

  4. **rest 후 max_conn 체크 제거**
     max_conn은 같은 duty 내 flight 간 연결 시간 제약인데, rest 이후 새 duty 시작에 잘못 적용되고 있었습니다.

  5. **multi-base 관련 코드 추가**
      - pairing 첫 편 반드시 base 출발 체크 추가
      -  END_PAIRING 시 base 미복귀면 BASE_PENALTY 차감

  ---

  ### RL/state.py (수정)
  **역할: 에피소드 시작 시 초기 state dict 생성 (딱 한 번 호출)**

  - constraint["base_airport"] 기반으로 초기 공항/시각 설정. base 출발 편 중 가장 이른 편을 current_time 기준으로 사용
  - 11개 필드 각각 인라인 주석 추가
  - duty_time과 duty_start_time 역할 구분 명시
    - `duty_time`: decoder state_vec feature용 누적 비행 시간
    - `duty_start_time`: get_mask()에서 FAA window 체크 기준점으로 사용

  ---

  ### RL/constraints.py + RL/airline_constraints/ (수정/new)
  **역할: 항공사별 운항 제약 정의 + FiLM 입력 키 순서 관리**

  기존에는 constraint 값이 get_delta_constraints() 함수 안에 딕셔너리로 박혀 있었습니다. 다른 항공사를 추가할 때 함수 열어서 비교/수정해야 해서 airline_constraints/ 디렉토리로 분리했습니다.
  - `airline_constraints/delta.py`: DELTA_CONSTRAINTS 상수 정의
  - `constraints.py`: import 후 반환만 담당
  - 새 항공사 추가 시 파일 하나 추가 + constraints.py에 한 줄이면 됩니다.
  - get_delta_constraints(base_airport: int): 에피소드별 base_airport를 주입받아 반환합니다. train.py에서 랜덤 선택 후 주입하는 구조입니다.

---

related issue #7