### PR TITLE
[Feat] decoder multi-base 설계 반영 - state_vec 확장 및 return_logits 추가

### DIFF
--- a/model/decoder.py
+++ b/model/decoder.py
@@ -20,9 +20,11 @@ class PointerDecoder(nn.Module):
         """
         super().__init__()
 
-        # state_vec(38,) = airport_emb(airport_emb_dim) + 6개 스칼라
+        # state_vec(70,) = current_airport_emb(airport_emb_dim) + base_airport_emb(airport_emb_dim) + 6개 스칼라
         # 6개: time_of_day, day_norm, duty_time/max, legs/max, duty_period/max, is_resting
-        state_input_dim = airport_emb_dim + 6
+        # base_airport_emb 추가 이유: multi-base 설계에서 에피소드마다 base가 달라지므로
+        # 모델이 "이번 에피소드 목표 base가 어디인지" 명시적으로 알아야 복귀 경로 계획 가능
+        state_input_dim = airport_emb_dim * 2 + 6
         self.state_mlp = nn.Sequential(
             nn.Linear(state_input_dim, d_model),
             nn.ReLU(),
@@ -47,14 +49,16 @@ class PointerDecoder(nn.Module):
         encoded_flights: torch.Tensor,
         state_vec: torch.Tensor,
         mask: torch.Tensor,
+        return_logits: bool = False,
     ) -> torch.Tensor:
         """
         Args:
             encoded_flights: (N, d_model)
-            state_vec: (airport_emb_dim+6,)
+            state_vec: (airport_emb_dim*2+6,) — current_emb + base_emb + scalars
             mask: (N+2,) — [...flights, END_DUTY, END_PAIRING]
+            return_logits: True면 softmax 전 raw score 반환 — REINFORCE log_prob 계산 시 수치 안정성
         Returns:
-            probs: (N+2,)
+            probs or logits: (N+2,)
         """
         q = self.state_mlp(state_vec)
         if self.skip_state_mlp:
@@ -70,6 +74,7 @@ class PointerDecoder(nn.Module):
 
         scores = (k @ q) / math.sqrt(self.d_model)  # (N+2,)
         scores[mask == 0] = float('-inf')
-        probs = F.softmax(scores, dim=-1)            # (N+2,)
 
-        return probs
+        if return_logits:
+            return scores                            # (N+2,) — F.log_softmax로 안정적 log_prob 계산
+        return F.softmax(scores, dim=-1)             # (N+2,)

--- a/model/decoder.py
+++ b/model/decoder.py
@@ -20,11 +20,13 @@ class PointerDecoder(nn.Module):
         """
         super().__init__()
 
-        # state_vec(70,) = current_airport_emb(airport_emb_dim) + base_airport_emb(airport_emb_dim) + 6개 스칼라
-        # 6개: time_of_day, day_norm, duty_time/max, legs/max, duty_period/max, is_resting
+        # state_vec(71,) = current_airport_emb(airport_emb_dim) + base_airport_emb(airport_emb_dim) + 7개 스칼라
+        # 7개: time_of_day, day_norm, duty_elapsed/max, legs/max, duty_period/max, is_resting, rest_remaining
         # base_airport_emb 추가 이유: multi-base 설계에서 에피소드마다 base가 달라지므로
         # 모델이 "이번 에피소드 목표 base가 어디인지" 명시적으로 알아야 복귀 경로 계획 가능
-        state_input_dim = airport_emb_dim * 2 + 6
+        # rest_remaining: is_resting=True일 때 (rest_end_time - current_time) / min_rest, 아니면 0.0
+        # TODO(train.py): state_to_vec()에 rest_remaining 스칼라 추가 필요 (6개 → 7개로 맞춰야 함)
+        state_input_dim = airport_emb_dim * 2 + 7
         self.state_mlp = nn.Sequential(
             nn.Linear(state_input_dim, d_model),
             nn.ReLU(),
@@ -54,7 +56,7 @@ class PointerDecoder(nn.Module):
         """
         Args:
             encoded_flights: (N, d_model)
-            state_vec: (airport_emb_dim*2+6,) — current_emb + base_emb + scalars
+            state_vec: (airport_emb_dim*2+7,) — current_emb + base_emb + scalars(7)
             mask: (N+2,) — [...flights, END_DUTY, END_PAIRING]
             return_logits: True면 softmax 전 raw score 반환 — REINFORCE log_prob 계산 시 수치 안정성
         Returns:

--- a/model/decoder.py
+++ b/model/decoder.py
@@ -13,9 +13,15 @@ class PointerDecoder(nn.Module):
     """
 
     def __init__(self, d_model: int = 128, airport_emb_dim: int = 32, skip_state_mlp: bool = False):
+        """
+        d_model: attention 공간 차원 (encoder d_model과 일치해야 함)
+        airport_emb_dim: state_vec 내 공항 embedding 차원 (encoder airport_emb_dim과 일치해야 함)
+        skip_state_mlp: ablation용 — True면 MLP(Linear→ReLU→Linear) 대신 linear projection만 사용
+        """
         super().__init__()
 
-        # state_to_vec: airport_emb(32) + [time_of_day, day_norm, duty_time, legs, duty_period, is_resting] = 38
+        # state_vec(38,) = airport_emb(airport_emb_dim) + 6개 스칼라
+        # 6개: time_of_day, day_norm, duty_time/max, legs/max, duty_period/max, is_resting
         state_input_dim = airport_emb_dim + 6
         self.state_mlp = nn.Sequential(
             nn.Linear(state_input_dim, d_model),


### PR DESCRIPTION
  ## 개요
multi-base 설계 반영 및 state 표현력 개선을 위해 decoder.py를 수정했습니다.

  ---

  ## 변경 내용

  ### model/decoder.py
  **역할: 매 step마다 현재 state(query)와 encoded_flights(key)를 attention으로 비교해 다음 action 확률 반환**

  1. **state_vec 38 → 71차원으로 확장**
     - `airport_emb_dim + 6` → `airport_emb_dim * 2 + 7`
     - base_airport_emb(32) 추가: multi-base 설계에서 에피소드마다 base가 달라지므로 모델이 목표 base를 명시적으로 알아야 복귀 경로 계획 가능
     - rest_remaining 스칼라 추가: is_resting=True일 때 남은 rest 시간 정보 제공 (기존 is_resting 플래그만으로는 얼마나 남았는지 알 수 없음)

  2. **return_logits 옵션 추가**
     - REINFORCE log_prob 계산 시 `torch.log(softmax(x))`보다 `F.log_softmax(x)`가 수치적으로 안정적
     - `return_logits=True`면 softmax 전 raw score 반환 → 외부에서 F.log_softmax 적용

  ---

  ## 추후 확인 필요
  - train.py `state_to_vec()`에 rest_remaining 스칼라 추가 필요 (6개 → 7개, TODO 주석 남겨둠)
  - encoder.py의 `airport_emb_dim`과 decoder 값 일치해야 함