### PR TITLE
feat: rolling window 로더 추가 및 hub_only 제거

### DIFF
--- a/RL/loader.py
+++ b/RL/loader.py
@@ -36,15 +36,19 @@ def get_bases(flights, n_bases=3):
 def load_flights(path, limit=50, seed=42, n_days_max=None):
     """BTS 데이터에서 flight 로드.
 
-    공항 인덱스: 로드된 subset 기준 빈도 내림차순 → index 0 = 허브.
-    에피소드 간 일관된 공항 ID가 필요하면 build_airport_map()으로 사전 계산하고
-    load_flights_rolling()에 airport_map으로 전달할 것.
+    공항 인덱스: 전체 CSV 기준 빈도 내림차순 → index 0 = 허브.
+    limit과 무관하게 항상 동일한 airport_map이 사용된다.
     """
     df = pd.read_csv(path)
     df = df[[
         "ORIGIN", "DEST", "CRS_DEP_TIME", "CRS_ARR_TIME", "FL_DATE"
     ]].dropna()
     df["FL_DATE"] = pd.to_datetime(df["FL_DATE"], format="mixed")
+
+    # 전체 데이터 기준으로 airport_map 구축 (subset 잘라내기 전에 계산)
+    airport_counts = Counter(list(df["ORIGIN"]) + list(df["DEST"]))
+    airports_sorted = sorted(airport_counts.keys(), key=lambda a: -airport_counts[a])
+    airport_map = {a: i for i, a in enumerate(airports_sorted)}
 
     if n_days_max is not None:
         dates = sorted(df["FL_DATE"].unique())[:n_days_max]
@@ -67,10 +71,6 @@ def load_flights(path, limit=50, seed=42, n_days_max=None):
     df["arr_time"] += df["day_offset"] * 24
 
     df = df.sort_values("dep_time").reset_index(drop=True)
-
-    airport_counts = Counter(list(df["ORIGIN"]) + list(df["DEST"]))
-    airports_sorted = sorted(airport_counts.keys(), key=lambda a: -airport_counts[a])
-    airport_map = {a: i for i, a in enumerate(airports_sorted)}
 
     df["origin"] = df["ORIGIN"].map(airport_map)
     df["dest"]   = df["DEST"].map(airport_map)

--- a/RL/loader.py
+++ b/RL/loader.py
@@ -116,23 +116,20 @@ def load_flights_rolling(
     path,
     window_days=5,
     offset_days=0,
-    limit=None,
     airport_map=None,
-    seed=42,
 ):
     """슬라이딩 윈도우 방식으로 실제 날짜 데이터 로드.
 
     에피소드마다 offset_days를 달리하면 서로 다른 flight 구성으로 훈련 가능.
     hub_only 없이 모든 노선(spoke-spoke 포함)을 그대로 사용한다.
+    flight 수는 window_days로만 제어한다 (개수 제한 없음).
 
     Args:
         path:         BTS CSV 경로
         window_days:  윈도우 크기 (일), 기본 5
         offset_days:  전체 날짜 목록 기준 시작 인덱스 (에피소드마다 랜덤 지정)
-        limit:        윈도우 내 최대 flight 수 (None = 전부)
         airport_map:  전체-데이터 기준 공항 ID 맵; None이면 전체 CSV에서 재계산(느림).
                       train 루프에서는 build_airport_map()으로 사전 계산 후 전달 권장.
-        seed:         limit 샘플링 랜덤 시드
 
     Returns:
         flight dict 리스트 (dep_time 오름차순 정렬)
@@ -166,13 +163,6 @@ def load_flights_rolling(
     df["arr_time"] += df["day_offset"] * 24
 
     df = df.sort_values("dep_time").reset_index(drop=True)
-
-    if limit is not None and len(df) > limit:
-        df = (
-            df.sample(n=limit, random_state=seed)
-            .sort_values("dep_time")
-            .reset_index(drop=True)
-        )
 
     df["origin"] = df["ORIGIN"].map(airport_map)
     df["dest"]   = df["DEST"].map(airport_map)

--- a/RL/loader.py
+++ b/RL/loader.py
@@ -9,46 +9,43 @@ def convert_time(hhmm):
     return h + m / 60
 
 
-def load_flights(path, limit=50, seed=42, n_days_max=None, hub_only=False):
+def build_airport_map(path):
+    """전체 BTS CSV 기준으로 공항→int 맵을 생성한다.
+
+    빈도 내림차순 정렬: index 0 = 가장 빈도 높은 공항(허브/base 후보).
+    에피소드마다 다른 rolling window를 써도 ID가 일관된다.
     """
-    BTS 데이터에서 flight 로드.
+    df = pd.read_csv(path, usecols=["ORIGIN", "DEST"]).dropna()
+    counts = Counter(list(df["ORIGIN"]) + list(df["DEST"]))
+    airports_sorted = sorted(counts.keys(), key=lambda a: -counts[a])
+    return {a: i for i, a in enumerate(airports_sorted)}
 
-    hub_only=True: 가장 빈도 높은 공항(허브)에 출발 또는 도착하는 flight만 포함.
-        → 모든 flight이 허브를 경유하므로 base-to-base pairing 항상 가능 → dummy 0개.
-        → 모든 flight이 허브를 경유하므로 base-to-base pairing 항상 가능.
 
-    공항 인덱스: 빈도 내림차순 정렬 → index 0 = 허브 = base_airport.
+def get_bases(flights, n_bases=3):
+    """flight dict 리스트에서 빈도 상위 n_bases개 공항 ID를 반환한다.
+
+    airport_map이 빈도 내림차순이므로 결과는 통상 [0, 1, ..., n_bases-1].
+    """
+    counts = Counter()
+    for f in flights:
+        counts[f["origin"]] += 1
+        counts[f["dest"]] += 1
+    return [a for a, _ in counts.most_common(n_bases)]
+
+
+def load_flights(path, limit=50, seed=42, n_days_max=None):
+    """BTS 데이터에서 flight 로드.
+
+    공항 인덱스: 로드된 subset 기준 빈도 내림차순 → index 0 = 허브.
+    에피소드 간 일관된 공항 ID가 필요하면 build_airport_map()으로 사전 계산하고
+    load_flights_rolling()에 airport_map으로 전달할 것.
     """
     df = pd.read_csv(path)
-
     df = df[[
-        "ORIGIN",
-        "DEST",
-        "CRS_DEP_TIME",
-        "CRS_ARR_TIME",
-        "FL_DATE"
+        "ORIGIN", "DEST", "CRS_DEP_TIME", "CRS_ARR_TIME", "FL_DATE"
     ]].dropna()
-
     df["FL_DATE"] = pd.to_datetime(df["FL_DATE"], format="mixed")
 
-    # 허브 결정: 전체 데이터에서 가장 빈도 높은 공항 (필터링 전 기준)
-    all_airports = list(df["ORIGIN"]) + list(df["DEST"])
-    hub = Counter(all_airports).most_common(1)[0][0]
-
-    # hub_only: round-trip 가능한 스포크 도시만 포함
-    #   전체 데이터 기준 ATL→X AND X→ATL 둘 다 존재하는 도시만 필터
-    #   샘플링 후 단방향만 들어간 도시 반복 제거 → 양방향 보장
-    if hub_only:
-        hub_to_spoke = set(df[df["ORIGIN"] == hub]["DEST"].unique()) - {hub}
-        spoke_to_hub = set(df[df["DEST"] == hub]["ORIGIN"].unique()) - {hub}
-        round_trip_cities = hub_to_spoke & spoke_to_hub
-        df = df[
-            ((df["ORIGIN"] == hub) & (df["DEST"].isin(round_trip_cities))) |
-            ((df["DEST"] == hub) & (df["ORIGIN"].isin(round_trip_cities)))
-        ].copy()
-
-    # 기본: head(limit)으로 앞에서부터 자름 (같은 날 데이터)
-    # n_days_max 지정 시: 날짜별 골고루 샘플링
     if n_days_max is not None:
         dates = sorted(df["FL_DATE"].unique())[:n_days_max]
         n_per_day = max(1, limit // len(dates))
@@ -61,116 +58,45 @@ def load_flights(path, limit=50, seed=42, n_days_max=None, hub_only=False):
     else:
         df = df.head(limit)
 
-    # hub_only 후처리:
-    # 1) 단방향 spoke city 제거 (샘플에서 한쪽 방향이 빠진 경우)
-    # 2) overnight timing 호환성 체크: 선행 duty가 overnight window 내 도착 불가한 flight 제거
-    #    (X→ATL flight인데 ATL→X 도착이 너무 늦어 min_rest 부족한 경우)
-    if hub_only:
-        df_pool = df.copy()  # 현재 head(limit) 결과
-        df_full_hub = df  # 이미 round_trip filter 적용된 전체
-
-        # 전체 round-trip pool (limit보다 훨씬 많음)
-        import pandas as _pd
-        df_all = _pd.read_csv(path)
-        df_all = df_all[["ORIGIN", "DEST", "CRS_DEP_TIME", "CRS_ARR_TIME", "FL_DATE"]].dropna()
-        df_all["FL_DATE"] = _pd.to_datetime(df_all["FL_DATE"], format="mixed")
-        hub_to_spoke_full = set(df_all[df_all["ORIGIN"] == hub]["DEST"].unique()) - {hub}
-        spoke_to_hub_full = set(df_all[df_all["DEST"] == hub]["ORIGIN"].unique()) - {hub}
-        rt_full = hub_to_spoke_full & spoke_to_hub_full
-        df_pool_full = df_all[
-            ((df_all["ORIGIN"] == hub) & (df_all["DEST"].isin(rt_full))) |
-            ((df_all["DEST"] == hub) & (df_all["ORIGIN"].isin(rt_full)))
-        ].copy()
-
-        # 현재 샘플에서 단방향 city 제거 → 부족분 보충 반복
-        for _ in range(10):
-            outbound = set(df[df["ORIGIN"] == hub]["DEST"]) - {hub}
-            inbound  = set(df[df["DEST"] == hub]["ORIGIN"]) - {hub}
-            connected = outbound & inbound
-            df = df[
-                ((df["ORIGIN"] == hub) & (df["DEST"].isin(connected))) |
-                ((df["DEST"] == hub) & (df["ORIGIN"].isin(connected)))
-            ]
-            if len(df) >= limit:
-                df = df.head(limit)
-                break
-            # 부족하면 pool에서 추가 rows 보충
-            used_idx = set(df.index)
-            extra = df_pool_full[~df_pool_full.index.isin(used_idx)].head(limit - len(df) + 20)
-            df = pd.concat([df, extra]).drop_duplicates()
-
     df["dep_time"] = df["CRS_DEP_TIME"].apply(convert_time)
     df["arr_time"] = df["CRS_ARR_TIME"].apply(convert_time)
 
     base_date = df["FL_DATE"].min()
     df["day_offset"] = (df["FL_DATE"] - base_date).dt.days
-
     df["dep_time"] += df["day_offset"] * 24
     df["arr_time"] += df["day_offset"] * 24
 
     df = df.sort_values("dep_time").reset_index(drop=True)
 
-    # hub_only: overnight timing 호환성 체크 (dep_time 변환 후)
-    # X→ATL flight: ATL→X flights이 24h expansion 후 올바른 overnight window로 도착 가능해야 함
-    # 4-day expansion 기준: day k의 X→ATL(dep=T)에 대해
-    #   preceding ATL→X arr_time이 [T-24-max_rest, T-24-min_rest] ∪ [T-max_rest, T-min_rest] 내에 있어야 함
-    # 간단 체크: ATL→X 최소 arrival(= min arr_time in df for DEST==X) + min_rest < X→ATL dep + 24
-    if hub_only:
-        MIN_REST = 8.0
-        MAX_REST = 24.0
-        # ATL→X: 각 spoke 공항 X에 대한 최소 도착 시간 (당일 가장 이른 ATL 출발 편)
-        outbound_min_arr = df[df["ORIGIN"] == hub].groupby("DEST")["arr_time"].min()
-        # X→ATL: 각 spoke 공항 X에 대한 최소 출발 시간
-        inbound_min_dep = df[df["DEST"] == hub].groupby("ORIGIN")["dep_time"].min()
-
-        def is_pairable(row):
-            """overnight [min_rest, max_rest] 내 연결 가능한 flight인지 체크"""
-            if row["ORIGIN"] == hub:
-                # ATL→X: day0 arr + min_rest < day1 X→ATL earliest dep (= dep+24)
-                x = row["DEST"]
-                if x not in inbound_min_dep:
-                    return False
-                # day0 ATL→X arr + min_rest ≤ day1 X→ATL dep (= inbound_dep + 24)
-                return row["arr_time"] + MIN_REST <= inbound_min_dep[x] + 24
-            else:
-                # X→ATL: day0 ATL→X earliest arr + min_rest ≤ day1 this flight dep
-                x = row["ORIGIN"]
-                if x not in outbound_min_arr:
-                    return False
-                # day1 dep = row["dep_time"] + 24
-                return outbound_min_arr[x] + MIN_REST <= row["dep_time"] + 24
-
-        mask = df.apply(is_pairable, axis=1)
-        df = df[mask].reset_index(drop=True)
-
-    # 공항 인덱스: 빈도 내림차순 → index 0 = 허브 = base_airport
     airport_counts = Counter(list(df["ORIGIN"]) + list(df["DEST"]))
     airports_sorted = sorted(airport_counts.keys(), key=lambda a: -airport_counts[a])
     airport_map = {a: i for i, a in enumerate(airports_sorted)}
 
     df["origin"] = df["ORIGIN"].map(airport_map)
-    df["dest"] = df["DEST"].map(airport_map)
+    df["dest"]   = df["DEST"].map(airport_map)
 
     flights = []
     for _, row in df.iterrows():
         flights.append({
-            "id": len(flights),
-            "origin": int(row["origin"]),
-            "dest": int(row["dest"]),
+            "id":       len(flights),
+            "origin":   int(row["origin"]),
+            "dest":     int(row["dest"]),
             "dep_time": float(row["dep_time"]),
-            "arr_time": float(row["arr_time"])
+            "arr_time": float(row["arr_time"]),
         })
 
     return flights
 
 
-def load_flights_multiday(path, limit=200, n_days=4, seed=42, hub_only=False):
+def load_flights_multiday(path, limit=200, n_days=4, seed=42):
     """같은 flight set을 n_days일치로 복제하여 multi-day 데이터 생성.
 
     동일한 flights를 매일 반복 → overnight connection이 자연 생성됨.
-    결과: limit × n_days 개의 flight (ID는 day * limit + original_id)
+    결과: limit × n_days 개의 flight (ID = day * limit + original_id)
+
+    NOTE: 다양성이 필요한 학습에는 load_flights_rolling() 사용 권장.
     """
-    base = load_flights(path, limit=limit, seed=seed, hub_only=hub_only)
+    base = load_flights(path, limit=limit, seed=seed)
 
     all_flights = []
     for day in range(n_days):
@@ -184,3 +110,82 @@ def load_flights_multiday(path, limit=200, n_days=4, seed=42, hub_only=False):
             })
 
     return all_flights
+
+
+def load_flights_rolling(
+    path,
+    window_days=5,
+    offset_days=0,
+    limit=None,
+    airport_map=None,
+    seed=42,
+):
+    """슬라이딩 윈도우 방식으로 실제 날짜 데이터 로드.
+
+    에피소드마다 offset_days를 달리하면 서로 다른 flight 구성으로 훈련 가능.
+    hub_only 없이 모든 노선(spoke-spoke 포함)을 그대로 사용한다.
+
+    Args:
+        path:         BTS CSV 경로
+        window_days:  윈도우 크기 (일), 기본 5
+        offset_days:  전체 날짜 목록 기준 시작 인덱스 (에피소드마다 랜덤 지정)
+        limit:        윈도우 내 최대 flight 수 (None = 전부)
+        airport_map:  전체-데이터 기준 공항 ID 맵; None이면 전체 CSV에서 재계산(느림).
+                      train 루프에서는 build_airport_map()으로 사전 계산 후 전달 권장.
+        seed:         limit 샘플링 랜덤 시드
+
+    Returns:
+        flight dict 리스트 (dep_time 오름차순 정렬)
+    """
+    df = pd.read_csv(path)
+    df = df[[
+        "ORIGIN", "DEST", "CRS_DEP_TIME", "CRS_ARR_TIME", "FL_DATE"
+    ]].dropna()
+    df["FL_DATE"] = pd.to_datetime(df["FL_DATE"], format="mixed")
+
+    # airport_map이 없으면 전체 데이터 기준으로 구축 (에피소드 간 ID 일관성 보장)
+    if airport_map is None:
+        counts = Counter(list(df["ORIGIN"]) + list(df["DEST"]))
+        airports_sorted = sorted(counts.keys(), key=lambda a: -counts[a])
+        airport_map = {a: i for i, a in enumerate(airports_sorted)}
+
+    # 윈도우 날짜 추출
+    dates = sorted(df["FL_DATE"].unique())
+    window_dates = dates[offset_days: offset_days + window_days]
+    if not window_dates:
+        return []
+
+    df = df[df["FL_DATE"].isin(window_dates)].copy()
+
+    # 시간 변환 + 윈도우 시작일 기준 day offset
+    df["dep_time"] = df["CRS_DEP_TIME"].apply(convert_time)
+    df["arr_time"] = df["CRS_ARR_TIME"].apply(convert_time)
+    base_date = min(window_dates)
+    df["day_offset"] = (df["FL_DATE"] - base_date).dt.days
+    df["dep_time"] += df["day_offset"] * 24
+    df["arr_time"] += df["day_offset"] * 24
+
+    df = df.sort_values("dep_time").reset_index(drop=True)
+
+    if limit is not None and len(df) > limit:
+        df = (
+            df.sample(n=limit, random_state=seed)
+            .sort_values("dep_time")
+            .reset_index(drop=True)
+        )
+
+    df["origin"] = df["ORIGIN"].map(airport_map)
+    df["dest"]   = df["DEST"].map(airport_map)
+    df = df.dropna(subset=["origin", "dest"])
+
+    flights = []
+    for _, row in df.iterrows():
+        flights.append({
+            "id":       len(flights),
+            "origin":   int(row["origin"]),
+            "dest":     int(row["dest"]),
+            "dep_time": float(row["dep_time"]),
+            "arr_time": float(row["arr_time"]),
+        })
+
+    return flights

--- a/RL/loader.py
+++ b/RL/loader.py
@@ -105,29 +105,6 @@ def load_flights(path, limit=50, seed=42, n_days_max=None):
     return flights
 
 
-def load_flights_multiday(path, limit=200, n_days=4, seed=42):
-    """같은 flight set을 n_days일치로 복제하여 multi-day 데이터 생성.
-
-    동일한 flights를 매일 반복 → overnight connection이 자연 생성됨.
-    결과: limit × n_days 개의 flight (ID = day * limit + original_id)
-
-    NOTE: 다양성이 필요한 학습에는 load_flights_rolling() 사용 권장.
-    """
-    base = load_flights(path, limit=limit, seed=seed)
-
-    all_flights = []
-    for day in range(n_days):
-        for f in base:
-            all_flights.append({
-                "id":       day * limit + f["id"],
-                "origin":   f["origin"],
-                "dest":     f["dest"],
-                "dep_time": f["dep_time"] + day * 24.0,
-                "arr_time": f["arr_time"] + day * 24.0,
-            })
-
-    return all_flights
-
 
 def load_flights_rolling(
     path,

--- a/RL/loader.py
+++ b/RL/loader.py
@@ -21,6 +21,23 @@ def build_airport_map(path):
     return {a: i for i, a in enumerate(airports_sorted)}
 
 
+def bases_to_ids(bases, airport_map):
+    """문자열 base 리스트를 정수 ID로 변환한다.
+
+    Args:
+        bases:       공항 코드 문자열 리스트 (예: ["ATL", "DTW", "MSP"])
+        airport_map: build_airport_map()으로 생성한 공항→int 맵
+
+    Returns:
+        정수 ID 리스트. airport_map에 없는 코드는 무시한다.
+    """
+    ids = [airport_map[b] for b in bases if b in airport_map]
+    if len(ids) < len(bases):
+        missing = [b for b in bases if b not in airport_map]
+        raise ValueError(f"airport_map에 없는 base: {missing}")
+    return ids
+
+
 def get_bases(flights, n_bases=3):
     """flight dict 리스트에서 빈도 상위 n_bases개 공항 ID를 반환한다.
 


### PR DESCRIPTION
## 개요

BTS 데이터 로딩 방식을 multi-base 학습에 맞게 전면 수정함.
hub_only 필터 제거, 동일 데이터 복제 문제 해결, 공항 ID 불일치 문제 수정,
crew base 명시적 입력을 위한 함수 추가.

**loader의 주 파이프라인은:
build_airport_map()  →  bases_to_ids()  →  load_flights_rolling()**
---

## 1. hub_only 필터 제거

**기존 코드 문제점**
- hub_only는 "RL이 ATL로 반드시 복귀해야 한다"는 조건을 데이터 레벨에서 강제하는 필터이다.
- 실제 데이터 전체를 그대로 반영하지 않아 spoke-spoke 항공편(BOS→ORD 등)을 전혀 학습할 수 없어 현실 운항 패턴과 달라진다.
- `MIN_REST = 8.0` 부분이 하드코딩되어 있어 `constraints.py` 기준 9.5h와 불일치 함.
- multi-base 환경에서는 ATL 이외의 base 기준 round-trip 보장이 불가능해 hub_only 개념 자체가 필요없다.

**수정**
- `load_flights()`에서 `hub_only` 파라미터 및 관련 블록 전체 제거.
- `load_flights_multiday()` 함수 자체 제거. 동일 데이터 반복이 문제의 본질이므로 하위 호환을 위한 유지도 불필요하다고 판단. `load_flights_rolling()`으로 대체.
**base 복귀는 environment의 BASE_PENALTY가 담당 예정(찬주 확인 부탁!!)**

---

## 2. 에피소드마다 동일한 데이터 반복

**기존 코드 문제점**
- 모든 에피소드가 완전히 동일한 800(200*4)개 flight를 반복해서 본다.
- 특정 dep_time 패턴에 과적합되어 다른 날짜 데이터에 대한 일반화가 없다.
- 날짜별 실제 운항 변동(계절, 요일)을 전혀 반영하지 못한다.
- 학습/평가 시간 분리(train-eval split)가 구조적으로 불가능하다.

**수정**
`load_flights_rolling(path, window_days, offset_days, airport_map)` 추가
- 실제 날짜 데이터를 슬라이딩 윈도우로 로드한다. 
- `offset_days`를 에피소드마다 다르게 지정하면 서로 다른 날짜 구간의 flight를 학습한다. 
- `window 안에서 랜덤 샘플링하면 시간 연속성이 깨지기 때문에 flight 수는 `window_days`로만 제어한다.

---

## 3. 에피소드 간 공항 ID 불일치 버그 (load_flights_rolling)

**기존 문제**
`load_flights()` 내부에서 로드된 subset 기준으로 airport_map을 재계산했다. rolling window를 쓰면 윈도우마다 포함되는 공항 집합이 달라지므로 같은 "BOS"가 윈도우 1에서 ID=3, 윈도우 2에서 ID=7이 될 수 있었다. 모델의 `airport_emb`는 ID를 인덱스로 사용하므로 ID가 바뀌면 embedding 학습이 무의미해진다.

**수정**
`build_airport_map(path)` 신설. 전체 CSV 기준으로 고정 맵을 한 번 만든다. 이후 모든 `load_flights_rolling()` 호출에 `airport_map=` 파라미터로 주입하면 어떤 윈도우를 쓰더라도 ATL=0, DTW=1, MSP=2가 항상 보장된다.

---

## 4. load_flights() 자체의 airport_map 버그

**기존 문제점**
`load_flights(limit=50)`과 `load_flights(limit=200)`이 서로 다른 airport_map을 생성한다. 학습에 `limit=200`, 평가에 `limit=50`을 쓰면 공항 ID가 달라져 embedding이 완전히 다른 공항을 가리킨다.

**수정**
`df.head(limit)` 이전에 전체 df 기준으로 airport_map을 먼저 계산한다.
```python
airport_counts = Counter(list(df["ORIGIN"]) + list(df["DEST"]))  # 전체 기준
airport_map = {a: i for i, a in enumerate(airports_sorted)}
df = df.head(limit)  # 이후 자름
```

---

## 5. bases_to_ids() 추가 — crew base 명시적 입력

**기존 문제**
기존코드에서는 빈도 기반으로 자동 계산(`get_bases()`)하거나 `base_airport=0`을 고정으로 썼다. 이를 crew base가 어디인지 외부에서 명시적으로 입력받도록 수정.
**수정**
`build_airport_map()`으로 만든 전체 CSV 기준 맵을 통해 문자열 코드를 정수 ID로 변환한다. 없는 코드가 있으면 즉시 오류를 발생시켜 잘못된 base 입력을 조기에 감지한다.

`get_bases(flights, n_bases)` 함수는 유지했고, 주 파이프라인에서는 `bases_to_ids()`를 통한 명시적 입력이 우선되도록 하였다.

---