### PR TITLE
[Feat] train.py multi-base rolling window 학습 구조 반영

### DIFF
--- a/RL/airline_constraints/delta.py
+++ b/RL/airline_constraints/delta.py
@@ -1,0 +1,14 @@
+# Delta 항공사 운항 제약값
+# TODO: base_airport = 0 하드코딩 → loader.py Global Airport Index 확정 후 ATL 실제 ID로 교체
+# 현재 per-airline 고정 방식 → multi-airline 확장 시 unified index 전환 여부 혜린과 합의 필요
+
+DELTA_CONSTRAINTS = {
+    "max_duty":        13.0,  # duty 최대 경과 시간 (h), FAA Part 117 테이블 최댓값
+    "min_conn":         0.5,  # 최소 연결 시간 (h, 30분)
+    "max_conn":         8.0,  # 최대 연결 시간 (h)
+    "max_legs":           4,  # duty당 최대 flight 수
+    "base_airport":       0,  # base 공항 ID (FiLM 입력 제외, 마스킹 전용)
+    "min_rest":         9.5,  # duty 간 최소 휴식 (h), FAA Part 117 기준
+    "max_duty_periods":   4,  # pairing당 최대 duty 수
+    "max_pairing_days":   5,  # pairing 최대 기간 (일)
+}

--- a/RL/airline_constraints/delta.py
+++ b/RL/airline_constraints/delta.py
@@ -7,8 +7,8 @@ DELTA_CONSTRAINTS = {
     "min_conn":         0.5,  # 최소 연결 시간 (h, 30분)
     "max_conn":         8.0,  # 최대 연결 시간 (h)
     "max_legs":           4,  # duty당 최대 flight 수
-    "base_airport":       0,  # base 공항 ID (FiLM 입력 제외, 마스킹 전용)
     "min_rest":         9.5,  # duty 간 최소 휴식 (h), FAA Part 117 기준
     "max_duty_periods":   4,  # pairing당 최대 duty 수
     "max_pairing_days":   5,  # pairing 최대 기간 (일)
+    # base_airport 제외 — get_delta_constraints(base_airport) 호출 시 에피소드별 주입
 }

--- a/RL/config.py
+++ b/RL/config.py
@@ -19,6 +19,7 @@ DEFAULT_CONSTRAINTS = {
     "max_pairing_days":    5,   # pairing 최대 기간 (일)
     "pairing_cost":      5.0,   # END_PAIRING reward 패널티
     "uncovered_penalty": 10.0,  # 미배정 flight 1개당 패널티
+    "base_penalty":      5.0,   # END_PAIRING 시 base 미복귀 패널티
 }
 
 # 커리큘럼 스테이지별 허용 규칙

--- a/RL/config.py
+++ b/RL/config.py
@@ -30,6 +30,19 @@ AIRLINE_BASES = {
     "jetblue": ["JFK", "BOS", "FLL"],
 }
 
+# Stage 3 FiLM augmentation constraint 범위 — 항공사별 constraint 확정 후 채울 것
+# (min, max) 튜플. train.py sample_constraint()에서 random.uniform/randint(*range)로 사용
+# TODO: constraint 확정 후 각 항공사 실제 범위로 교체
+STAGE3_CONSTRAINT_RANGES = {
+    "max_duty":         (12.0, 14.0),   # TODO: constraint 기준 확정 필요
+    "min_rest":         (10.0, 11.0),   # TODO: constraint 기준 확정 필요
+    "min_conn":         (0.5,  1.0),    # TODO: constraint 기준 확정 필요
+    "max_conn":         (3.0,  4.0),    # TODO: constraint 기준 확정 필요
+    "max_legs":         (3,    4),      # TODO: constraint 기준 확정 필요
+    "max_duty_periods": (3,    4),      # TODO: constraint 기준 확정 필요
+    "max_pairing_days": (3,    5),      # TODO: constraint 기준 확정 필요
+}
+
 # 커리큘럼 스테이지별 허용 규칙
 # Stage 1: 단일 duty (END_DUTY 불가) — 기본 연결 패턴 학습
 # Stage 2: multi-day (END_DUTY 가능) — overnight + base 복귀 학습

--- a/RL/config.py
+++ b/RL/config.py
@@ -1,0 +1,32 @@
+# Action 인덱스 (numpy 음수 인덱싱 활용 — mask[-2], mask[-1])
+END_DUTY    = -2
+END_PAIRING = -1
+
+# FAA Part 117 — duty 내 leg 수 기준 최대 flight duty period (hours)
+# 추후 항공사 확장 시 다른 규정 테이블로 교체 가능
+FAA_DUTY_TABLE = {1: 13.0, 2: 13.0, 3: 12.0, 4: 11.5, 5: 11.0, 6: 10.5}
+
+# Delta 기본 제약 — FiLM constraint vector(7,) 및 마스킹 기본값
+# TODO: base_airport = 0 하드코딩 → loader.py Global Airport Index 확정 후 ATL 실제 ID로 교체
+DEFAULT_CONSTRAINTS = {
+    "max_duty":         13.0,   # duty 최대 경과 시간 (h)
+    "min_conn":          0.5,   # 최소 연결 시간 (h, 30분)
+    "max_conn":          8.0,   # 최대 연결 시간 (h)
+    "max_legs":            4,   # duty당 최대 flight 수
+    "base_airport":        0,   # base 공항 ID (Global Index 확정 전 임시값)
+    "min_rest":          9.5,   # duty 간 최소 휴식 (h)
+    "max_duty_periods":    4,   # pairing당 최대 duty 수
+    "max_pairing_days":    5,   # pairing 최대 기간 (일)
+    "pairing_cost":      5.0,   # END_PAIRING reward 패널티
+    "uncovered_penalty": 10.0,  # 미배정 flight 1개당 패널티
+}
+
+# 커리큘럼 스테이지별 허용 규칙
+# Stage 1: 단일 duty (END_DUTY 불가) — 기본 연결 패턴 학습
+# Stage 2: multi-day (END_DUTY 가능) — overnight + base 복귀 학습
+# Stage 3: Stage 2 + constraint 랜덤화 — FiLM 적응 학습
+CURRICULUM_CONFIG = {
+    1: {"allow_end_duty": False},
+    2: {"allow_end_duty": True},
+    3: {"allow_end_duty": True},
+}

--- a/RL/config.py
+++ b/RL/config.py
@@ -22,6 +22,14 @@ DEFAULT_CONSTRAINTS = {
     "base_penalty":      5.0,   # END_PAIRING 시 base 미복귀 패널티
 }
 
+# 항공사 설정 — 항공사 바꿀 때 AIRLINE만 수정하면 됨 (현재 코드는 예시임 !!)
+AIRLINE = "delta"
+AIRLINE_BASES = {
+    "delta":   ["ATL", "DTW", "MSP", "JFK", "LAX"],
+    "alaska":  ["SEA", "PDX", "ANC"],
+    "jetblue": ["JFK", "BOS", "FLL"],
+}
+
 # 커리큘럼 스테이지별 허용 규칙
 # Stage 1: 단일 duty (END_DUTY 불가) — 기본 연결 패턴 학습
 # Stage 2: multi-day (END_DUTY 가능) — overnight + base 복귀 학습

--- a/RL/config.py
+++ b/RL/config.py
@@ -40,7 +40,7 @@ STAGE3_CONSTRAINT_RANGES = {
     "max_conn":         (3.0,  4.0),    # TODO: constraint 기준 확정 필요
     "max_legs":         (3,    4),      # TODO: constraint 기준 확정 필요
     "max_duty_periods": (3,    4),      # TODO: constraint 기준 확정 필요
-    "max_pairing_days": (3,    5),      # TODO: constraint 기준 확정 필요
+    "max_pairing_days": (3,    4),      # TODO: constraint 기준 확정 필요 / 상한은 WINDOW_DAYS(4)로 제한
 }
 
 # 커리큘럼 스테이지별 허용 규칙

--- a/RL/config.py
+++ b/RL/config.py
@@ -30,6 +30,21 @@ AIRLINE_BASES = {
     "jetblue": ["JFK", "BOS", "FLL"],
 }
 
+# FiLM 입력 정규화 기준값 — constraint 값을 [0, 1]로 정규화하기 위한 분모
+# 각 항목별 실제 상한값 (항공사 중 최대 or 여유값)
+# TODO: constraint 확정 후 항공사별 실제 상한으로 교체
+# evaluate_ip.py도 동일한 값을 써야 checkpoint 호환 — 수정 시 혜린 확인 필요
+# 지금 값은 우선 evaluate_ip.py 참조
+CONSTRAINT_NORMS = {
+    "max_duty":         14.0,   # JetBlue constraint 상한
+    "min_conn":          1.0,   # Stage3 범위 상한
+    "max_conn":          8.0,   # DEFAULT_CONSTRAINTS 기준
+    "max_legs":          6.0,   # 실제 사용값(4)보다 여유
+    "min_rest":         12.0,   # Southwest(11.0)보다 여유
+    "max_duty_periods":  5.0,   # 실제 사용값(4)보다 여유
+    "max_pairing_days":  7.0,   # 실제 사용값(4~5)보다 여유
+}
+
 # Stage 3 FiLM augmentation constraint 범위 — 항공사별 constraint 확정 후 채울 것
 # (min, max) 튜플. train.py sample_constraint()에서 random.uniform/randint(*range)로 사용
 # TODO: constraint 확정 후 각 항공사 실제 범위로 교체

--- a/RL/config.py
+++ b/RL/config.py
@@ -58,6 +58,14 @@ STAGE3_CONSTRAINT_RANGES = {
     "max_pairing_days": (3,    4),      # TODO: constraint 기준 확정 필요 / 상한은 WINDOW_DAYS(4)로 제한
 }
 
+# Phase 2 CG dual feedback 하이퍼파라미터
+# pool rollout 수: pool이 너무 작으면 LP가 의미없고, 너무 많으면 느림 → 30번이 균형점
+# LP interval: 매 에피소드 LP를 풀면 CBC solver가 병목 → 10 에피소드마다 재풀기
+# (dual_vars는 interval 사이에 캐싱되어 재사용됨)
+PHASE2_POOL_ROLLOUTS = 30    # pool 수집 rollout 수 (stochastic × 30 + greedy × 1)
+PHASE2_LP_INTERVAL   = 10    # LP re-solve 주기 (에피소드)
+PHASE2_N_EPISODES    = 1000  # Phase 2 학습 에피소드 수
+
 # 커리큘럼 스테이지별 허용 규칙
 # Stage 1: 단일 duty (END_DUTY 불가) — 기본 연결 패턴 학습
 # Stage 2: multi-day (END_DUTY 가능) — overnight + base 복귀 학습

--- a/RL/config.py
+++ b/RL/config.py
@@ -58,6 +58,11 @@ STAGE3_CONSTRAINT_RANGES = {
     "max_pairing_days": (3,    4),      # TODO: constraint 기준 확정 필요 / 상한은 WINDOW_DAYS(4)로 제한
 }
 
+# 슬라이딩 윈도우 크기 — max_pairing_days 상한과 맞춰야 window 밖 deadhead 방지
+# Stage 2/3, Phase 2 모두 max_pairing_days = WINDOW_DAYS로 제한
+# TODO: 혜린 확인 필요
+WINDOW_DAYS = 4
+
 # Phase 2 CG dual feedback 하이퍼파라미터
 # pool rollout 수: pool이 너무 작으면 LP가 의미없고, 너무 많으면 느림 → 30번이 균형점
 # LP interval: 매 에피소드 LP를 풀면 CBC solver가 병목 → 10 에피소드마다 재풀기

--- a/RL/constraints.py
+++ b/RL/constraints.py
@@ -16,13 +16,16 @@ from airline_constraints.delta import DELTA_CONSTRAINTS
 # from airline_constraints.ua import TURKISH_CONSTRAINTS  # 이런식으로 추후 추가
 
 
-def get_delta_constraints():
+def get_delta_constraints(base_airport: int):
     """Delta 항공사 constraint dict 반환
 
+    base_airport: 에피소드별 base 공항 ID
+    # TODO: loader.py [Base Input] 단계에서 사용자가 입력한 base를 train.py가 받아서 여기에 주입하는 구조
+    # loader.py가 선택된 base를 train.py에 어떻게 넘겨주는지 혜린 PR 확인 후 train.py 호출 위치 확정 필요
     FiLM constraint vector(7,) 입력 및 environment.py 마스킹에 사용.
-    base_airport는 FiLM 입력에서 제외 (카테고리형 → FILM_CONSTRAINT_KEYS에 없음).
+    base_airport는 FiLM 입력에서 제외 (카테고리형 → FILM_CONSTRAINT_KEYS에 없음)
     """
-    return DELTA_CONSTRAINTS
+    return {**DELTA_CONSTRAINTS, "base_airport": base_airport}
 
 
 # FiLM 입력 constraint 키 순서 — constraint_to_tensor()가 이 순서대로 tensor 변환 → shape (7,)

--- a/RL/constraints.py
+++ b/RL/constraints.py
@@ -1,26 +1,38 @@
+# constraints.py — 항공사별 운항 제약 정의
+#
+# 역할:
+#   - get_<airline>_constraints(): 항공사별 constraint dict 반환 → environment.py 마스킹 + FiLM 입력에 사용
+#   - FILM_CONSTRAINT_KEYS: constraint dict 중 FiLM에 넣을 7개 키 순서 정의
+#
+# config.py와의 관계:
+#   - config.DEFAULT_CONSTRAINTS: constraint가 없을 때 environment.py가 쓰는 fallback (+ reward 상수 포함)
+#   - constraints.py: 항공사별 실제 값의 출처 (train.py가 이걸 읽어서 environment에 넘기도록)
+#   - reward 상수(pairing_cost, uncovered_penalty)는 config.py에서만 관리 — 여기에 넣지 않음
+
+
+# 항공사별 constraint 값은 airline_constraints/ 에서 관리
+# 새 항공사 추가 시 airline_constraints/<airline>.py 파일 추가 후 아래에 get 함수 작성
+from airline_constraints.delta import DELTA_CONSTRAINTS
+# from airline_constraints.ua import TURKISH_CONSTRAINTS  # 이런식으로 추후 추가
+
+
 def get_delta_constraints():
-    return {
-        # 현재 적용 (5개)
-        "max_duty":         13.0,   # duty 최대 경과 시간 (시간, FAA Part 117 테이블 최댓값)
-        "min_conn":          0.5,   # 최소 연결 시간 (30분)
-        "max_conn":          8.0,   # 최대 연결 시간 (8시간)
-        "max_legs":          4,     # duty당 최대 flights
-        "base_airport":      0,     # base 공항 ID (FiLM 제외)
+    """Delta 항공사 constraint dict 반환
 
-        # multi-day (FAA Part 117 기반)
-        "min_rest":          9.5,   # duty 간 최소 휴식 (시간)
-        "max_duty_periods":  4,     # pairing당 최대 duty 횟수
-        "max_pairing_days":  5,     # pairing 최대 기간 (일)
-    }
+    FiLM constraint vector(7,) 입력 및 environment.py 마스킹에 사용.
+    base_airport는 FiLM 입력에서 제외 (카테고리형 → FILM_CONSTRAINT_KEYS에 없음).
+    """
+    return DELTA_CONSTRAINTS
 
 
-# FiLM 입력 constraint key (base_airport는 카테고리이므로 제외)
+# FiLM 입력 constraint 키 순서 — constraint_to_tensor()가 이 순서대로 tensor 변환 → shape (7,)
+# base_airport는 카테고리형이라 제외
 FILM_CONSTRAINT_KEYS = [
-    "max_duty",
-    "min_conn",
-    "max_conn",
-    "max_legs",
-    "min_rest",
-    "max_duty_periods",
-    "max_pairing_days",
+    "max_duty",         # 0
+    "min_conn",         # 1
+    "max_conn",         # 2
+    "max_legs",         # 3
+    "min_rest",         # 4
+    "max_duty_periods", # 5
+    "max_pairing_days", # 6
 ]

--- a/RL/constraints.py
+++ b/RL/constraints.py
@@ -20,8 +20,8 @@ def get_delta_constraints(base_airport: int):
     """Delta 항공사 constraint dict 반환
 
     base_airport: 에피소드별 base 공항 ID
-    # TODO: loader.py [Base Input] 단계에서 사용자가 입력한 base를 train.py가 받아서 여기에 주입하는 구조
-    # loader.py가 선택된 base를 train.py에 어떻게 넘겨주는지 혜린 PR 확인 후 train.py 호출 위치 확정 필요
+    - bases_to_ids(["ATL", "DTW", ...], airport_map) → 정수 ID 리스트 반환
+    - train.py에서 그 중 하나 랜덤 선택하고 여기에 주입하는 구조
     FiLM constraint vector(7,) 입력 및 environment.py 마스킹에 사용.
     base_airport는 FiLM 입력에서 제외 (카테고리형 → FILM_CONSTRAINT_KEYS에 없음)
     """

--- a/RL/environment.py
+++ b/RL/environment.py
@@ -44,7 +44,11 @@ def get_mask(state, flights, assigned, constraint=None, stage=3):
         valid = True
 
         # 1. 공항 연결 검사
-        if not pairing_start and f["origin"] != state["current_airport"]:
+        # pairing 첫 leg base 출발 강제 (hub_only 제거로 전체 편이 후보에 포함되니까 명시적 체크)
+        if pairing_start:
+            if f["origin"] != c.get("base_airport", config.DEFAULT_CONSTRAINTS["base_airport"]):
+                valid = False
+        elif f["origin"] != state["current_airport"]:
             valid = False
 
         # 2. 시간 연결 검사
@@ -93,10 +97,10 @@ def get_mask(state, flights, assigned, constraint=None, stage=3):
     # END_PAIRING (mask[-1] = mask[N+1])
     pairing_elapsed_days = (state["current_time"] - pairing_start_time) / 24.0
     can_end_pairing = (
-        state["current_airport"] == c.get("base_airport", config.DEFAULT_CONSTRAINTS["base_airport"])
-        and state.get("legs", 0) > 0
+        state.get("legs", 0) > 0
         and pairing_elapsed_days <= c.get("max_pairing_days", config.DEFAULT_CONSTRAINTS["max_pairing_days"])
     )
+    # base 미복귀 시 BASE_PENALTY는 step()에서 reward로 처리 (hard mask 제거 → soft penalty)
     if can_end_pairing:
         mask[config.END_PAIRING] = 1
 
@@ -133,15 +137,22 @@ def step(state, action, flights, assigned, constraint=None):
     # END_PAIRING → pairing 비용 부과 후 새 pairing 시작 (또는 에피소드 종료)
     if action == N + 1:
         p_cost = c.get("pairing_cost", config.DEFAULT_CONSTRAINTS["pairing_cost"])
+        base_penalty = c.get("base_penalty", config.DEFAULT_CONSTRAINTS["base_penalty"])
+        # constraint["base_airport"] 에피소드별 주입
+        base = c.get("base_airport", config.DEFAULT_CONSTRAINTS["base_airport"])
+        reward = -p_cost
+        if state["current_airport"] != base:
+            reward -= base_penalty
         unassigned = [f for f in flights if not assigned[f["id"]]]
         if not unassigned:
             # 모든 flight 커버 완료 → 에피소드 종료
-            return state, -p_cost, True
-        # 미배정 flight 남아있음 → 새 pairing 시작
-        next_time = min(f["dep_time"] for f in unassigned)
+            return state, reward, True
+        # 미배정 flight 남아있음 → 새 pairing 시작 (base 출발 편 중 가장 이른 편 기준)
+        base_unassigned = [f for f in unassigned if f["origin"] == base]
+        next_time = min(f["dep_time"] for f in base_unassigned) if base_unassigned else min(f["dep_time"] for f in unassigned)
         next_state = {
             **state,
-            "current_airport":    c.get("base_airport", config.DEFAULT_CONSTRAINTS["base_airport"]),
+            "current_airport":    base,
             "current_time":       next_time,
             "duty_time":          0.0,
             "duty_start_time":    next_time,
@@ -152,7 +163,7 @@ def step(state, action, flights, assigned, constraint=None):
             "pairing_start":      True,
             "pairing_start_time": next_time,
         }
-        return next_state, -p_cost, False
+        return next_state, reward, False
 
     # Flight 선택
     f = flights[action]

--- a/RL/environment.py
+++ b/RL/environment.py
@@ -1,115 +1,185 @@
-END_DUTY = -2     # 현재 duty 종료 → rest period 진입, pairing 계속
-END_PAIRING = -1  # pairing 전체 종료
+import numpy as np
+import config
+
+# TODO: 혜린 loader.py 확인
+# flight dict 키 이름 ("origin", "dest", "dep_time", "arr_time", "id") 변경 여부
+# environment.py 전체에서 이 키를 직접 참조하므로 이름 바뀌면 같이 수정 필요
 
 
-def get_max_duty(legs_after, constraint):
-    """FAA Part 117 — duty에 추가될 leg 수 기준 max flight duty period (hours)"""
-    table = {1: 13.0, 2: 13.0, 3: 12.0, 4: 11.5, 5: 11.0, 6: 10.5}
-    return table.get(min(legs_after, 6), 10.0)
+def get_max_duty(legs_count, custom_max_duty=None):
+    """FAA Part 117과 항공사 정책 중 더 엄격한 duty 시간 한도 반환
 
-
-def get_mask(state, flights, assigned, constraint):
+    legs_count: 해당 duty에 추가될 leg 수 (현재 legs + 1)
+    custom_max_duty: constraint["max_duty"] 값. None이면 DEFAULT_CONSTRAINTS 사용
     """
-    반환: [flight_0, ..., flight_N-1, END_DUTY, END_PAIRING]
-    인덱스: 0..N-1 = flight, N = END_DUTY, N+1 = END_PAIRING
+    faa_limit = config.FAA_DUTY_TABLE.get(min(legs_count, 6), 10.0)
+    if custom_max_duty is not None:
+        return min(faa_limit, custom_max_duty)
+    return min(faa_limit, config.DEFAULT_CONSTRAINTS["max_duty"])
+
+
+def get_mask(state, flights, assigned, constraint=None, stage=3):
+    """현재 state에서 선택 가능한 action 마스크 반환
+
+    반환: 크기 [N + 2]의 list (0: 불가, 1: 가능)
+         index 0..N-1 = flight, N = END_DUTY, N+1 = END_PAIRING
     """
-    mask = []
-    pairing_start = state.get("pairing_start", False)
-    is_resting = state.get("is_resting", False)
-    rest_end = state.get("rest_end_time")
-    duty_period = state.get("duty_period", 0)
-    max_duty_periods = constraint.get("max_duty_periods", 4)
-    max_pairing_days = constraint.get("max_pairing_days", 5)
+    c = constraint if constraint else config.DEFAULT_CONSTRAINTS
+    stage_rule = config.CURRICULUM_CONFIG.get(stage, config.CURRICULUM_CONFIG[3])
+
+    N = len(flights)
+    mask = np.zeros(N + 2, dtype=np.int32)
+
+    pairing_start    = state.get("pairing_start", False)
+    is_resting       = state.get("is_resting", False)
+    rest_end         = state.get("rest_end_time", 0.0)
+    duty_period      = state.get("duty_period", 0)
+    duty_start_time  = state.get("duty_start_time", state["current_time"])
     pairing_start_time = state.get("pairing_start_time", state["current_time"])
 
-    for f in flights:
+    for i, f in enumerate(flights):
         if assigned[f["id"]]:
-            mask.append(0)
             continue
-
-        flight_time = f["arr_time"] - f["dep_time"]
-        gap = f["dep_time"] - state["current_time"]
 
         valid = True
 
-        # rest 중이면 rest_end_time 이후 출발 flight만 허용
-        if is_resting:
-            if rest_end is not None and f["dep_time"] < rest_end:
-                valid = False
-
-        legs_after = state.get("legs", 0) + 1
-        effective_max_duty = min(get_max_duty(legs_after, constraint), constraint.get("max_duty", 13.0))
-
-        if pairing_start:
-            if state.get("duty_time", 0.0) + flight_time > effective_max_duty:
-                valid = False
-            if legs_after > constraint.get("max_legs", 999):
-                valid = False
-        else:
-            if not is_resting:
-                if f["origin"] != state["current_airport"]:
-                    valid = False
-                if gap < constraint["min_conn"] or gap > constraint["max_conn"]:
-                    valid = False
-                if state["duty_time"] + flight_time > effective_max_duty:
-                    valid = False
-                if legs_after > constraint.get("max_legs", 999):
-                    valid = False
-            else:
-                # rest 종료 후 새 duty 시작: 공항 연결 체크, connection 제약은 없음
-                if f["origin"] != state["current_airport"]:
-                    valid = False
-
-        # pairing 기간 초과 방지
-        elapsed_days = (f["dep_time"] - pairing_start_time) / 24.0
-        if elapsed_days > max_pairing_days:
+        # 1. 공항 연결 검사
+        if not pairing_start and f["origin"] != state["current_airport"]:
             valid = False
 
-        mask.append(1 if valid else 0)
+        # 2. 시간 연결 검사
+        if is_resting:
+            # rest 미종료 시 탑승 불가
+            if f["dep_time"] < rest_end:
+                valid = False
+        else:
+            if not pairing_start:
+                gap = f["dep_time"] - state["current_time"]
+                if gap < c.get("min_conn", config.DEFAULT_CONSTRAINTS["min_conn"]) or \
+                   gap > c.get("max_conn", config.DEFAULT_CONSTRAINTS["max_conn"]):
+                    valid = False
 
-    # END_DUTY: 현재 duty에 leg가 있고, 추가 duty period 여유가 있고, rest 중 아닐 때
+        # 3. Duty 시간 제약 (FAA Part 117)
+        # duty window = duty 시작 ~ 해당 flight 도착까지 전체 경과 시간
+        # pairing 첫 편이거나 rest 직후 새 duty 시작이면 기준점을 해당 편 출발로 리셋
+        legs_after = state.get("legs", 0) + 1
+        effective_max_duty = get_max_duty(legs_after, c.get("max_duty"))
+        current_duty_start = f["dep_time"] if (pairing_start or is_resting) else duty_start_time
+        total_duty_window = f["arr_time"] - current_duty_start
+        if total_duty_window > effective_max_duty:
+            valid = False
+        if legs_after > c.get("max_legs", config.DEFAULT_CONSTRAINTS["max_legs"]):
+            valid = False
+
+        # 4. Pairing 기간 제약
+        elapsed_days = (f["arr_time"] - pairing_start_time) / 24.0
+        if elapsed_days > c.get("max_pairing_days", config.DEFAULT_CONSTRAINTS["max_pairing_days"]):
+            valid = False
+
+        if valid:
+            mask[i] = 1
+
+    # END_DUTY (mask[-2] = mask[N])
     can_end_duty = (
-        state.get("legs", 0) > 0
+        stage_rule["allow_end_duty"]
+        and state.get("legs", 0) > 0
         and not is_resting
         and not pairing_start
-        and duty_period < max_duty_periods - 1
+        and duty_period < c.get("max_duty_periods", config.DEFAULT_CONSTRAINTS["max_duty_periods"]) - 1
     )
-    mask.append(1 if can_end_duty else 0)
+    if can_end_duty:
+        mask[config.END_DUTY] = 1
 
-    # END_PAIRING: base에 있고 leg가 있고 pairing 기간 내
+    # END_PAIRING (mask[-1] = mask[N+1])
     pairing_elapsed_days = (state["current_time"] - pairing_start_time) / 24.0
     can_end_pairing = (
-        state["current_airport"] == constraint["base_airport"]
+        state["current_airport"] == c.get("base_airport", config.DEFAULT_CONSTRAINTS["base_airport"])
         and state.get("legs", 0) > 0
-        and pairing_elapsed_days <= max_pairing_days
+        and pairing_elapsed_days <= c.get("max_pairing_days", config.DEFAULT_CONSTRAINTS["max_pairing_days"])
     )
-    mask.append(1 if can_end_pairing else 0)
+    if can_end_pairing:
+        mask[config.END_PAIRING] = 1
 
-    return mask
+    return mask.tolist()
 
 
-def step(state, action, flights, assigned, constraint):
+def step(state, action, flights, assigned, constraint=None):
+    """action을 받아 next_state, reward, done 반환
+
+    action 범위:
+      0 .. N-1  : flight 선택
+      N         : END_DUTY
+      N+1       : END_PAIRING
+    done=True 조건: END_PAIRING 선택 시 모든 flight가 커버된 경우
+    """
+    c = constraint if constraint else config.DEFAULT_CONSTRAINTS
+    N = len(flights)
+
+    # END_DUTY → rest 진입, pairing 계속
+    if action == N:
+        min_rest = c.get("min_rest", config.DEFAULT_CONSTRAINTS["min_rest"])
+        next_state = {
+            **state,
+            "duty_time":       0.0,
+            "duty_start_time": state["current_time"] + min_rest,
+            "legs":            0,
+            "is_resting":      True,
+            "rest_end_time":   state["current_time"] + min_rest,
+            "duty_period":     state.get("duty_period", 0) + 1,
+            "pairing_start":   False,
+        }
+        return next_state, 0.0, False
+
+    # END_PAIRING → pairing 비용 부과 후 새 pairing 시작 (또는 에피소드 종료)
+    if action == N + 1:
+        p_cost = c.get("pairing_cost", config.DEFAULT_CONSTRAINTS["pairing_cost"])
+        unassigned = [f for f in flights if not assigned[f["id"]]]
+        if not unassigned:
+            # 모든 flight 커버 완료 → 에피소드 종료
+            return state, -p_cost, True
+        # 미배정 flight 남아있음 → 새 pairing 시작
+        next_time = min(f["dep_time"] for f in unassigned)
+        next_state = {
+            **state,
+            "current_airport":    c.get("base_airport", config.DEFAULT_CONSTRAINTS["base_airport"]),
+            "current_time":       next_time,
+            "duty_time":          0.0,
+            "duty_start_time":    next_time,
+            "legs":               0,
+            "duty_period":        0,
+            "is_resting":         False,
+            "rest_end_time":      None,
+            "pairing_start":      True,
+            "pairing_start_time": next_time,
+        }
+        return next_state, -p_cost, False
+
+    # Flight 선택
     f = flights[action]
     assigned[f["id"]] = True
-
     flight_time = f["arr_time"] - f["dep_time"]
+
+    # pairing 첫 편이면 pairing_start_time 리셋, rest 직후 새 duty면 duty_start_time 리셋
+    p_start_time = f["dep_time"] if state.get("pairing_start", False) else state["pairing_start_time"]
+    d_start_time = f["dep_time"] if (state.get("pairing_start", False) or state.get("is_resting", False)) \
+                   else state["duty_start_time"]
 
     next_state = {
         "current_airport":    f["dest"],
         "current_time":       f["arr_time"],
-        "duty_time":          state["duty_time"] + flight_time,
-        "duty_start_time":    state["duty_start_time"],
+        "duty_time":          (0.0 if state.get("is_resting", False) else state["duty_time"]) + flight_time,
+        "duty_start_time":    d_start_time,
         "legs":               state.get("legs", 0) + 1,
         "remaining":          state["remaining"] - 1,
         "pairing_start":      False,
-        # multi-day 필드 전파
         "duty_period":        state.get("duty_period", 0),
-        "pairing_start_time": state.get("pairing_start_time", state["current_time"]),
+        "pairing_start_time": p_start_time,
         "is_resting":         False,
         "rest_end_time":      None,
     }
 
-    # dead time: duty 내 flight 간 연결 대기 시간 (pairing 첫 flight나 rest 직후는 제외)
+    # dead time reward: duty 중간 flight 간 대기 시간만 패널티
+    # pairing 첫 편이거나 rest 직후 첫 편은 대기 시간 없으므로 제외
     if not state.get("pairing_start", False) and not state.get("is_resting", False):
         reward = -(f["dep_time"] - state["current_time"])
     else:
@@ -118,21 +188,8 @@ def step(state, action, flights, assigned, constraint):
     return next_state, reward, False
 
 
-def step_end_duty(state, constraint):
-    """현재 duty 종료 → rest period 진입, pairing은 계속"""
-    min_rest = constraint.get("min_rest", 9.5)
-    return {
-        **state,
-        "duty_time":       0.0,
-        "duty_start_time": state["current_time"] + min_rest,
-        "legs":            0,
-        "is_resting":      True,
-        "rest_end_time":   state["current_time"] + min_rest,
-        "duty_period":     state.get("duty_period", 0) + 1,
-        "pairing_start":   False,
-    }
-
-
-def final_reward(assigned, uncovered_penalty=10.0):
+def final_reward(assigned, custom_penalty=None):
+    """에피소드 종료 시 미배정 flight에 대한 패널티 반환"""
+    penalty = custom_penalty if custom_penalty is not None else config.DEFAULT_CONSTRAINTS["uncovered_penalty"]
     remaining = sum(1 for v in assigned.values() if not v)
-    return -uncovered_penalty * remaining
+    return -penalty * remaining

--- a/RL/environment.py
+++ b/RL/environment.py
@@ -1,9 +1,7 @@
 import numpy as np
 import config
 
-# TODO: 혜린 loader.py 확인
-# flight dict 키 이름 ("origin", "dest", "dep_time", "arr_time", "id") 변경 여부
-# environment.py 전체에서 이 키를 직접 참조하므로 이름 바뀌면 같이 수정 필요
+# flight dict 키: "origin", "dest", "dep_time", "arr_time", "id" 
 
 
 def get_max_duty(legs_count, custom_max_duty=None):

--- a/RL/loader.py
+++ b/RL/loader.py
@@ -36,15 +36,19 @@ def get_bases(flights, n_bases=3):
 def load_flights(path, limit=50, seed=42, n_days_max=None):
     """BTS 데이터에서 flight 로드.
 
-    공항 인덱스: 로드된 subset 기준 빈도 내림차순 → index 0 = 허브.
-    에피소드 간 일관된 공항 ID가 필요하면 build_airport_map()으로 사전 계산하고
-    load_flights_rolling()에 airport_map으로 전달할 것.
+    공항 인덱스: 전체 CSV 기준 빈도 내림차순 → index 0 = 허브.
+    limit과 무관하게 항상 동일한 airport_map이 사용된다.
     """
     df = pd.read_csv(path)
     df = df[[
         "ORIGIN", "DEST", "CRS_DEP_TIME", "CRS_ARR_TIME", "FL_DATE"
     ]].dropna()
     df["FL_DATE"] = pd.to_datetime(df["FL_DATE"], format="mixed")
+
+    # 전체 데이터 기준으로 airport_map 구축 (subset 잘라내기 전에 계산)
+    airport_counts = Counter(list(df["ORIGIN"]) + list(df["DEST"]))
+    airports_sorted = sorted(airport_counts.keys(), key=lambda a: -airport_counts[a])
+    airport_map = {a: i for i, a in enumerate(airports_sorted)}
 
     if n_days_max is not None:
         dates = sorted(df["FL_DATE"].unique())[:n_days_max]
@@ -67,10 +71,6 @@ def load_flights(path, limit=50, seed=42, n_days_max=None):
     df["arr_time"] += df["day_offset"] * 24
 
     df = df.sort_values("dep_time").reset_index(drop=True)
-
-    airport_counts = Counter(list(df["ORIGIN"]) + list(df["DEST"]))
-    airports_sorted = sorted(airport_counts.keys(), key=lambda a: -airport_counts[a])
-    airport_map = {a: i for i, a in enumerate(airports_sorted)}
 
     df["origin"] = df["ORIGIN"].map(airport_map)
     df["dest"]   = df["DEST"].map(airport_map)

--- a/RL/loader.py
+++ b/RL/loader.py
@@ -116,23 +116,20 @@ def load_flights_rolling(
     path,
     window_days=5,
     offset_days=0,
-    limit=None,
     airport_map=None,
-    seed=42,
 ):
     """슬라이딩 윈도우 방식으로 실제 날짜 데이터 로드.
 
     에피소드마다 offset_days를 달리하면 서로 다른 flight 구성으로 훈련 가능.
     hub_only 없이 모든 노선(spoke-spoke 포함)을 그대로 사용한다.
+    flight 수는 window_days로만 제어한다 (개수 제한 없음).
 
     Args:
         path:         BTS CSV 경로
         window_days:  윈도우 크기 (일), 기본 5
         offset_days:  전체 날짜 목록 기준 시작 인덱스 (에피소드마다 랜덤 지정)
-        limit:        윈도우 내 최대 flight 수 (None = 전부)
         airport_map:  전체-데이터 기준 공항 ID 맵; None이면 전체 CSV에서 재계산(느림).
                       train 루프에서는 build_airport_map()으로 사전 계산 후 전달 권장.
-        seed:         limit 샘플링 랜덤 시드
 
     Returns:
         flight dict 리스트 (dep_time 오름차순 정렬)
@@ -166,13 +163,6 @@ def load_flights_rolling(
     df["arr_time"] += df["day_offset"] * 24
 
     df = df.sort_values("dep_time").reset_index(drop=True)
-
-    if limit is not None and len(df) > limit:
-        df = (
-            df.sample(n=limit, random_state=seed)
-            .sort_values("dep_time")
-            .reset_index(drop=True)
-        )
 
     df["origin"] = df["ORIGIN"].map(airport_map)
     df["dest"]   = df["DEST"].map(airport_map)

--- a/RL/loader.py
+++ b/RL/loader.py
@@ -9,46 +9,43 @@ def convert_time(hhmm):
     return h + m / 60
 
 
-def load_flights(path, limit=50, seed=42, n_days_max=None, hub_only=False):
+def build_airport_map(path):
+    """전체 BTS CSV 기준으로 공항→int 맵을 생성한다.
+
+    빈도 내림차순 정렬: index 0 = 가장 빈도 높은 공항(허브/base 후보).
+    에피소드마다 다른 rolling window를 써도 ID가 일관된다.
     """
-    BTS 데이터에서 flight 로드.
+    df = pd.read_csv(path, usecols=["ORIGIN", "DEST"]).dropna()
+    counts = Counter(list(df["ORIGIN"]) + list(df["DEST"]))
+    airports_sorted = sorted(counts.keys(), key=lambda a: -counts[a])
+    return {a: i for i, a in enumerate(airports_sorted)}
 
-    hub_only=True: 가장 빈도 높은 공항(허브)에 출발 또는 도착하는 flight만 포함.
-        → 모든 flight이 허브를 경유하므로 base-to-base pairing 항상 가능 → dummy 0개.
-        → 모든 flight이 허브를 경유하므로 base-to-base pairing 항상 가능.
 
-    공항 인덱스: 빈도 내림차순 정렬 → index 0 = 허브 = base_airport.
+def get_bases(flights, n_bases=3):
+    """flight dict 리스트에서 빈도 상위 n_bases개 공항 ID를 반환한다.
+
+    airport_map이 빈도 내림차순이므로 결과는 통상 [0, 1, ..., n_bases-1].
+    """
+    counts = Counter()
+    for f in flights:
+        counts[f["origin"]] += 1
+        counts[f["dest"]] += 1
+    return [a for a, _ in counts.most_common(n_bases)]
+
+
+def load_flights(path, limit=50, seed=42, n_days_max=None):
+    """BTS 데이터에서 flight 로드.
+
+    공항 인덱스: 로드된 subset 기준 빈도 내림차순 → index 0 = 허브.
+    에피소드 간 일관된 공항 ID가 필요하면 build_airport_map()으로 사전 계산하고
+    load_flights_rolling()에 airport_map으로 전달할 것.
     """
     df = pd.read_csv(path)
-
     df = df[[
-        "ORIGIN",
-        "DEST",
-        "CRS_DEP_TIME",
-        "CRS_ARR_TIME",
-        "FL_DATE"
+        "ORIGIN", "DEST", "CRS_DEP_TIME", "CRS_ARR_TIME", "FL_DATE"
     ]].dropna()
-
     df["FL_DATE"] = pd.to_datetime(df["FL_DATE"], format="mixed")
 
-    # 허브 결정: 전체 데이터에서 가장 빈도 높은 공항 (필터링 전 기준)
-    all_airports = list(df["ORIGIN"]) + list(df["DEST"])
-    hub = Counter(all_airports).most_common(1)[0][0]
-
-    # hub_only: round-trip 가능한 스포크 도시만 포함
-    #   전체 데이터 기준 ATL→X AND X→ATL 둘 다 존재하는 도시만 필터
-    #   샘플링 후 단방향만 들어간 도시 반복 제거 → 양방향 보장
-    if hub_only:
-        hub_to_spoke = set(df[df["ORIGIN"] == hub]["DEST"].unique()) - {hub}
-        spoke_to_hub = set(df[df["DEST"] == hub]["ORIGIN"].unique()) - {hub}
-        round_trip_cities = hub_to_spoke & spoke_to_hub
-        df = df[
-            ((df["ORIGIN"] == hub) & (df["DEST"].isin(round_trip_cities))) |
-            ((df["DEST"] == hub) & (df["ORIGIN"].isin(round_trip_cities)))
-        ].copy()
-
-    # 기본: head(limit)으로 앞에서부터 자름 (같은 날 데이터)
-    # n_days_max 지정 시: 날짜별 골고루 샘플링
     if n_days_max is not None:
         dates = sorted(df["FL_DATE"].unique())[:n_days_max]
         n_per_day = max(1, limit // len(dates))
@@ -61,116 +58,45 @@ def load_flights(path, limit=50, seed=42, n_days_max=None, hub_only=False):
     else:
         df = df.head(limit)
 
-    # hub_only 후처리:
-    # 1) 단방향 spoke city 제거 (샘플에서 한쪽 방향이 빠진 경우)
-    # 2) overnight timing 호환성 체크: 선행 duty가 overnight window 내 도착 불가한 flight 제거
-    #    (X→ATL flight인데 ATL→X 도착이 너무 늦어 min_rest 부족한 경우)
-    if hub_only:
-        df_pool = df.copy()  # 현재 head(limit) 결과
-        df_full_hub = df  # 이미 round_trip filter 적용된 전체
-
-        # 전체 round-trip pool (limit보다 훨씬 많음)
-        import pandas as _pd
-        df_all = _pd.read_csv(path)
-        df_all = df_all[["ORIGIN", "DEST", "CRS_DEP_TIME", "CRS_ARR_TIME", "FL_DATE"]].dropna()
-        df_all["FL_DATE"] = _pd.to_datetime(df_all["FL_DATE"], format="mixed")
-        hub_to_spoke_full = set(df_all[df_all["ORIGIN"] == hub]["DEST"].unique()) - {hub}
-        spoke_to_hub_full = set(df_all[df_all["DEST"] == hub]["ORIGIN"].unique()) - {hub}
-        rt_full = hub_to_spoke_full & spoke_to_hub_full
-        df_pool_full = df_all[
-            ((df_all["ORIGIN"] == hub) & (df_all["DEST"].isin(rt_full))) |
-            ((df_all["DEST"] == hub) & (df_all["ORIGIN"].isin(rt_full)))
-        ].copy()
-
-        # 현재 샘플에서 단방향 city 제거 → 부족분 보충 반복
-        for _ in range(10):
-            outbound = set(df[df["ORIGIN"] == hub]["DEST"]) - {hub}
-            inbound  = set(df[df["DEST"] == hub]["ORIGIN"]) - {hub}
-            connected = outbound & inbound
-            df = df[
-                ((df["ORIGIN"] == hub) & (df["DEST"].isin(connected))) |
-                ((df["DEST"] == hub) & (df["ORIGIN"].isin(connected)))
-            ]
-            if len(df) >= limit:
-                df = df.head(limit)
-                break
-            # 부족하면 pool에서 추가 rows 보충
-            used_idx = set(df.index)
-            extra = df_pool_full[~df_pool_full.index.isin(used_idx)].head(limit - len(df) + 20)
-            df = pd.concat([df, extra]).drop_duplicates()
-
     df["dep_time"] = df["CRS_DEP_TIME"].apply(convert_time)
     df["arr_time"] = df["CRS_ARR_TIME"].apply(convert_time)
 
     base_date = df["FL_DATE"].min()
     df["day_offset"] = (df["FL_DATE"] - base_date).dt.days
-
     df["dep_time"] += df["day_offset"] * 24
     df["arr_time"] += df["day_offset"] * 24
 
     df = df.sort_values("dep_time").reset_index(drop=True)
 
-    # hub_only: overnight timing 호환성 체크 (dep_time 변환 후)
-    # X→ATL flight: ATL→X flights이 24h expansion 후 올바른 overnight window로 도착 가능해야 함
-    # 4-day expansion 기준: day k의 X→ATL(dep=T)에 대해
-    #   preceding ATL→X arr_time이 [T-24-max_rest, T-24-min_rest] ∪ [T-max_rest, T-min_rest] 내에 있어야 함
-    # 간단 체크: ATL→X 최소 arrival(= min arr_time in df for DEST==X) + min_rest < X→ATL dep + 24
-    if hub_only:
-        MIN_REST = 8.0
-        MAX_REST = 24.0
-        # ATL→X: 각 spoke 공항 X에 대한 최소 도착 시간 (당일 가장 이른 ATL 출발 편)
-        outbound_min_arr = df[df["ORIGIN"] == hub].groupby("DEST")["arr_time"].min()
-        # X→ATL: 각 spoke 공항 X에 대한 최소 출발 시간
-        inbound_min_dep = df[df["DEST"] == hub].groupby("ORIGIN")["dep_time"].min()
-
-        def is_pairable(row):
-            """overnight [min_rest, max_rest] 내 연결 가능한 flight인지 체크"""
-            if row["ORIGIN"] == hub:
-                # ATL→X: day0 arr + min_rest < day1 X→ATL earliest dep (= dep+24)
-                x = row["DEST"]
-                if x not in inbound_min_dep:
-                    return False
-                # day0 ATL→X arr + min_rest ≤ day1 X→ATL dep (= inbound_dep + 24)
-                return row["arr_time"] + MIN_REST <= inbound_min_dep[x] + 24
-            else:
-                # X→ATL: day0 ATL→X earliest arr + min_rest ≤ day1 this flight dep
-                x = row["ORIGIN"]
-                if x not in outbound_min_arr:
-                    return False
-                # day1 dep = row["dep_time"] + 24
-                return outbound_min_arr[x] + MIN_REST <= row["dep_time"] + 24
-
-        mask = df.apply(is_pairable, axis=1)
-        df = df[mask].reset_index(drop=True)
-
-    # 공항 인덱스: 빈도 내림차순 → index 0 = 허브 = base_airport
     airport_counts = Counter(list(df["ORIGIN"]) + list(df["DEST"]))
     airports_sorted = sorted(airport_counts.keys(), key=lambda a: -airport_counts[a])
     airport_map = {a: i for i, a in enumerate(airports_sorted)}
 
     df["origin"] = df["ORIGIN"].map(airport_map)
-    df["dest"] = df["DEST"].map(airport_map)
+    df["dest"]   = df["DEST"].map(airport_map)
 
     flights = []
     for _, row in df.iterrows():
         flights.append({
-            "id": len(flights),
-            "origin": int(row["origin"]),
-            "dest": int(row["dest"]),
+            "id":       len(flights),
+            "origin":   int(row["origin"]),
+            "dest":     int(row["dest"]),
             "dep_time": float(row["dep_time"]),
-            "arr_time": float(row["arr_time"])
+            "arr_time": float(row["arr_time"]),
         })
 
     return flights
 
 
-def load_flights_multiday(path, limit=200, n_days=4, seed=42, hub_only=False):
+def load_flights_multiday(path, limit=200, n_days=4, seed=42):
     """같은 flight set을 n_days일치로 복제하여 multi-day 데이터 생성.
 
     동일한 flights를 매일 반복 → overnight connection이 자연 생성됨.
-    결과: limit × n_days 개의 flight (ID는 day * limit + original_id)
+    결과: limit × n_days 개의 flight (ID = day * limit + original_id)
+
+    NOTE: 다양성이 필요한 학습에는 load_flights_rolling() 사용 권장.
     """
-    base = load_flights(path, limit=limit, seed=seed, hub_only=hub_only)
+    base = load_flights(path, limit=limit, seed=seed)
 
     all_flights = []
     for day in range(n_days):
@@ -184,3 +110,82 @@ def load_flights_multiday(path, limit=200, n_days=4, seed=42, hub_only=False):
             })
 
     return all_flights
+
+
+def load_flights_rolling(
+    path,
+    window_days=5,
+    offset_days=0,
+    limit=None,
+    airport_map=None,
+    seed=42,
+):
+    """슬라이딩 윈도우 방식으로 실제 날짜 데이터 로드.
+
+    에피소드마다 offset_days를 달리하면 서로 다른 flight 구성으로 훈련 가능.
+    hub_only 없이 모든 노선(spoke-spoke 포함)을 그대로 사용한다.
+
+    Args:
+        path:         BTS CSV 경로
+        window_days:  윈도우 크기 (일), 기본 5
+        offset_days:  전체 날짜 목록 기준 시작 인덱스 (에피소드마다 랜덤 지정)
+        limit:        윈도우 내 최대 flight 수 (None = 전부)
+        airport_map:  전체-데이터 기준 공항 ID 맵; None이면 전체 CSV에서 재계산(느림).
+                      train 루프에서는 build_airport_map()으로 사전 계산 후 전달 권장.
+        seed:         limit 샘플링 랜덤 시드
+
+    Returns:
+        flight dict 리스트 (dep_time 오름차순 정렬)
+    """
+    df = pd.read_csv(path)
+    df = df[[
+        "ORIGIN", "DEST", "CRS_DEP_TIME", "CRS_ARR_TIME", "FL_DATE"
+    ]].dropna()
+    df["FL_DATE"] = pd.to_datetime(df["FL_DATE"], format="mixed")
+
+    # airport_map이 없으면 전체 데이터 기준으로 구축 (에피소드 간 ID 일관성 보장)
+    if airport_map is None:
+        counts = Counter(list(df["ORIGIN"]) + list(df["DEST"]))
+        airports_sorted = sorted(counts.keys(), key=lambda a: -counts[a])
+        airport_map = {a: i for i, a in enumerate(airports_sorted)}
+
+    # 윈도우 날짜 추출
+    dates = sorted(df["FL_DATE"].unique())
+    window_dates = dates[offset_days: offset_days + window_days]
+    if not window_dates:
+        return []
+
+    df = df[df["FL_DATE"].isin(window_dates)].copy()
+
+    # 시간 변환 + 윈도우 시작일 기준 day offset
+    df["dep_time"] = df["CRS_DEP_TIME"].apply(convert_time)
+    df["arr_time"] = df["CRS_ARR_TIME"].apply(convert_time)
+    base_date = min(window_dates)
+    df["day_offset"] = (df["FL_DATE"] - base_date).dt.days
+    df["dep_time"] += df["day_offset"] * 24
+    df["arr_time"] += df["day_offset"] * 24
+
+    df = df.sort_values("dep_time").reset_index(drop=True)
+
+    if limit is not None and len(df) > limit:
+        df = (
+            df.sample(n=limit, random_state=seed)
+            .sort_values("dep_time")
+            .reset_index(drop=True)
+        )
+
+    df["origin"] = df["ORIGIN"].map(airport_map)
+    df["dest"]   = df["DEST"].map(airport_map)
+    df = df.dropna(subset=["origin", "dest"])
+
+    flights = []
+    for _, row in df.iterrows():
+        flights.append({
+            "id":       len(flights),
+            "origin":   int(row["origin"]),
+            "dest":     int(row["dest"]),
+            "dep_time": float(row["dep_time"]),
+            "arr_time": float(row["arr_time"]),
+        })
+
+    return flights

--- a/RL/loader.py
+++ b/RL/loader.py
@@ -105,29 +105,6 @@ def load_flights(path, limit=50, seed=42, n_days_max=None):
     return flights
 
 
-def load_flights_multiday(path, limit=200, n_days=4, seed=42):
-    """같은 flight set을 n_days일치로 복제하여 multi-day 데이터 생성.
-
-    동일한 flights를 매일 반복 → overnight connection이 자연 생성됨.
-    결과: limit × n_days 개의 flight (ID = day * limit + original_id)
-
-    NOTE: 다양성이 필요한 학습에는 load_flights_rolling() 사용 권장.
-    """
-    base = load_flights(path, limit=limit, seed=seed)
-
-    all_flights = []
-    for day in range(n_days):
-        for f in base:
-            all_flights.append({
-                "id":       day * limit + f["id"],
-                "origin":   f["origin"],
-                "dest":     f["dest"],
-                "dep_time": f["dep_time"] + day * 24.0,
-                "arr_time": f["arr_time"] + day * 24.0,
-            })
-
-    return all_flights
-
 
 def load_flights_rolling(
     path,

--- a/RL/loader.py
+++ b/RL/loader.py
@@ -21,6 +21,23 @@ def build_airport_map(path):
     return {a: i for i, a in enumerate(airports_sorted)}
 
 
+def bases_to_ids(bases, airport_map):
+    """문자열 base 리스트를 정수 ID로 변환한다.
+
+    Args:
+        bases:       공항 코드 문자열 리스트 (예: ["ATL", "DTW", "MSP"])
+        airport_map: build_airport_map()으로 생성한 공항→int 맵
+
+    Returns:
+        정수 ID 리스트. airport_map에 없는 코드는 무시한다.
+    """
+    ids = [airport_map[b] for b in bases if b in airport_map]
+    if len(ids) < len(bases):
+        missing = [b for b in bases if b not in airport_map]
+        raise ValueError(f"airport_map에 없는 base: {missing}")
+    return ids
+
+
 def get_bases(flights, n_bases=3):
     """flight dict 리스트에서 빈도 상위 n_bases개 공항 ID를 반환한다.
 

--- a/RL/state.py
+++ b/RL/state.py
@@ -2,13 +2,17 @@ def init_state(flights, constraint):
     """에피소드 초기 state 생성
 
     flights: loader.py가 반환한 flight dict 리스트 (dep_time 기준 오름차순 정렬)
-    constraint: 미사용 — 시그니처 통일 목적으로만 받음. 실제 제약 적용은 environment.py에서 수행.
+    constraint: 에피소드별 constraint dict — base_airport 등 초기화에 사용
     """
-    first = flights[0]
+    base = constraint["base_airport"]
+    base_flights = [f for f in flights if f["origin"] == base]
+    # base 출발 편이 없으면 flights[0] fallback
+    # TODO: loader.py가 base 출발 편 포함된 window만 보장해주면 이 분기 불필요함! - 추후 혜린 PR 확인 필요
+    first = min(base_flights, key=lambda f: f["dep_time"]) if base_flights else flights[0]
 
     return {
         # 현재 위치 / 시각
-        "current_airport":    first["origin"],       # 현재 승무원 위치 공항 ID
+        "current_airport":    base,                   # 현재 승무원 위치 공항 ID (에피소드 base)
         "current_time":       first["dep_time"],      # 현재 시각 (절대시간, hours)
 
         # duty 내부 추적

--- a/RL/state.py
+++ b/RL/state.py
@@ -7,7 +7,8 @@ def init_state(flights, constraint):
     base = constraint["base_airport"]
     base_flights = [f for f in flights if f["origin"] == base]
     # base 출발 편이 없으면 flights[0] fallback
-    # TODO: loader.py가 base 출발 편 포함된 window만 보장해주면 이 분기 불필요함! - 추후 혜린 PR 확인 필요
+    # load_flights_rolling()은 전체 편 포함 → base 출발 편 미보장
+    # fallback 유지 / base 출발 편 없는 window는 train.py에서 에피소드 스킵 처리 필요
     first = min(base_flights, key=lambda f: f["dep_time"]) if base_flights else flights[0]
 
     return {

--- a/RL/state.py
+++ b/RL/state.py
@@ -1,17 +1,32 @@
 def init_state(flights, constraint):
+    """에피소드 초기 state 생성
+
+    flights: loader.py가 반환한 flight dict 리스트 (dep_time 기준 오름차순 정렬)
+    constraint: 미사용 — 시그니처 통일 목적으로만 받음. 실제 제약 적용은 environment.py에서 수행.
+    """
     first = flights[0]
 
     return {
-        "current_airport":    first["origin"],
-        "current_time":       first["dep_time"],
+        # 현재 위치 / 시각
+        "current_airport":    first["origin"],       # 현재 승무원 위치 공항 ID
+        "current_time":       first["dep_time"],      # 현재 시각 (절대시간, hours)
+
+        # duty 내부 추적
+        # duty_time: decoder 입력 feature용 누적 비행 시간 (h)
+        # FAA duty window 한도 체크는 duty_start_time 기준으로 get_mask()에서 별도 계산
         "duty_time":          0.0,
-        "duty_start_time":    first["dep_time"],
-        "legs":               0,
-        "remaining":          len(flights),
-        "pairing_start":      True,
-        # multi-day 필드
-        "duty_period":        0,
-        "pairing_start_time": first["dep_time"],
-        "is_resting":         False,
-        "rest_end_time":      None,
+        "duty_start_time":    first["dep_time"],      # 현재 duty 시작 시각 (FAA window 기준점)
+        "legs":               0,                      # 현재 duty 내 선택된 flight 수
+
+        # 에피소드 전체 추적
+        "remaining":          len(flights),           # 미배정 flight 수
+
+        # pairing 상태
+        "pairing_start":      True,                   # 새 pairing 시작 직후 — True면 공항/시간 체크 스킵
+        "duty_period":        0,                      # 현재 pairing 내 완료된 duty 수
+        "pairing_start_time": first["dep_time"],      # pairing 전체 기간 계산 기준점
+
+        # rest 상태
+        "is_resting":         False,                  # END_DUTY 후 rest 중 여부
+        "rest_end_time":      None,                   # rest 종료 시각 (is_resting=True일 때 유효)
     }

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -349,15 +349,18 @@ def train():
     # 매 에피소드 7개 constraint 전부 랜덤 샘플링 → FiLM이 다양한 constraint에 적응
     stage3_base = {**base_constraint, "max_duty_periods": 4, "max_pairing_days": 5}
     def sample_constraint():
+        # 범위는 config.STAGE3_CONSTRAINT_RANGES에서 관리
+        # TODO: 범위 확정 후 config.py 범위 수정 
+        r = config.STAGE3_CONSTRAINT_RANGES
         return {
             **stage3_base,
-            "max_duty":         random.uniform(12.0, 14.0),
-            "min_rest":         random.uniform(10.0, 11.0),
-            "min_conn":         random.uniform(0.5,  1.0),
-            "max_conn":         random.uniform(3.0,  4.0),
-            "max_legs":         random.randint(3, 4),
-            "max_duty_periods": random.randint(3, 4),
-            "max_pairing_days": random.randint(3, 5),
+            "max_duty":         random.uniform(*r["max_duty"]),
+            "min_rest":         random.uniform(*r["min_rest"]),
+            "min_conn":         random.uniform(*r["min_conn"]),
+            "max_conn":         random.uniform(*r["max_conn"]),
+            "max_legs":         random.randint(*r["max_legs"]),
+            "max_duty_periods": random.randint(*r["max_duty_periods"]),
+            "max_pairing_days": random.randint(*r["max_pairing_days"]),
         }
 
     run_curriculum_stage(3, encoder, decoder, optimizer,
@@ -399,7 +402,7 @@ def train():
         "decoder":        decoder.state_dict(),
         "n_airports":     n_airports,
         "constraint_dim": len(FILM_CONSTRAINT_KEYS),
-        "bases":          DELTA_BASES,
+        "bases":          airline_bases,
         "window_days":    WINDOW_DAYS,
     }, os.path.join(save_dir, "model_latest.pt"))
     print(f"\n모델 저장: checkpoints/model_latest.pt")

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -202,14 +202,16 @@ def run_episode(flights, constraint, encoder, decoder, encoded, greedy=False):
 
 
 def run_curriculum_stage(
-    stage, flights, encoder, decoder, optimizer, origins, dests, dep_times, arr_times,
-    n_episodes, constraint_override, save_dir, constraint_sampler=None
+    stage, encoder, decoder, optimizer,
+    n_episodes, constraint_override, save_dir,
+    flight_sampler, constraint_sampler=None,
 ):
     """
     커리큘럼 1단계 실행.
-    constraint_override: 기본 constraint dict.
-    constraint_sampler: 매 에피소드 constraint를 샘플링하는 함수 (FiLM 학습용).
-                        None이면 constraint_override 고정 사용.
+
+    flight_sampler: () → (flights, origins, dests, dep_times, arr_times, base_airport)
+                    에피소드마다 호출 — (base, window) 쌍 랜덤 선택 + flight 로드
+    constraint_sampler: () → constraint dict. None이면 constraint_override 고정 사용.
     """
     best_avg_pairings = float("inf")
     greedy_pairings = []
@@ -223,7 +225,14 @@ def run_curriculum_stage(
     params = list(encoder.parameters()) + list(decoder.parameters())
 
     for ep in range(n_episodes):
+        # 에피소드마다 (base, window) 랜덤 선택
+        sample = flight_sampler()
+        if sample is None:
+            continue
+        flights, origins, dests, dep_times, arr_times, base_airport = sample
+
         c = constraint_sampler() if constraint_sampler else constraint_override
+        c = {**c, "base_airport": base_airport}  # 에피소드별 base 주입
         c_tensor = constraint_to_tensor(c)
         encoded  = encoder(origins, dests, dep_times, arr_times, c_tensor)
 
@@ -280,10 +289,22 @@ def run_curriculum_stage(
 
 
 def train():
-    flights    = load_flights_multiday("RL/data/T_ONTIME_MARKETING.csv", limit=50, n_days=4, hub_only=True)
-    n_airports = max(max(f["origin"], f["dest"]) for f in flights) + 1
+    DATA_PATH   = "RL/data/T_ONTIME_MARKETING.csv"
+    # TODO: 협의 필요 — 우선 max_pairing_days=4(Delta CBA) 기준으로 4일 설정
+    # window가 pairing 최대 기간과 맞아야 한 에피소드 안에서 완성된 pairing 학습 가능
+    WINDOW_DAYS = 4
 
-    print(f"flights: {len(flights)}개, airports: {n_airports}개")
+    # TODO(loader PR #10 머지 후): bases_to_ids()는 loader.py에서 import해서 사용
+    # 현재는 loader PR #10이 미머지 상태라 build_airport_map + bases_to_ids 직접 호출
+    # DELTA_BASES: 연구자가 도메인 지식으로 직접 입력하는 crew base 목록
+    DELTA_BASES = ["ATL", "DTW", "MSP", "JFK", "LAX"]
+
+    # 전체 CSV 기준 공항 ID 고정 (에피소드 간 ID 일관성 보장)
+    airport_map = build_airport_map(DATA_PATH)
+    base_ids    = bases_to_ids(DELTA_BASES, airport_map)
+    n_airports  = len(airport_map)
+
+    print(f"airports: {n_airports}개, bases: {DELTA_BASES}")
 
     encoder = FlightEncoder(
         n_airports=n_airports,
@@ -298,37 +319,66 @@ def train():
     save_dir = os.path.join(os.path.dirname(__file__), "..", "checkpoints")
     os.makedirs(save_dir, exist_ok=True)
 
-    origins, dests, dep_times, arr_times = flights_to_tensors(flights)
+    # 전체 날짜 수 파악 → offset_days 범위 결정
+    import pandas as pd
+    df_dates = pd.read_csv(DATA_PATH, usecols=["FL_DATE"])
+    df_dates["FL_DATE"] = pd.to_datetime(df_dates["FL_DATE"], format="mixed")
+    total_days = df_dates["FL_DATE"].nunique()
+    max_offset = max(0, total_days - WINDOW_DAYS)
 
-    base = get_delta_constraints()
+    def flight_sampler():
+        """에피소드마다 (base, window) 쌍 랜덤 선택 → flight 로드"""
+        base_airport = random.choice(base_ids)
+        offset_days  = random.randint(0, max_offset)
+        flights = load_flights_rolling(DATA_PATH, WINDOW_DAYS, offset_days, airport_map)
+        if not flights:
+            return None
+        # base 출발 편 없는 window는 스킵 (state.py fallback 방지)
+        if not any(f["origin"] == base_airport for f in flights):
+            return None
+        origins, dests, dep_times, arr_times = flights_to_tensors(flights, WINDOW_DAYS)
+        return flights, origins, dests, dep_times, arr_times, base_airport
+
+    base_constraint = get_delta_constraints(base_ids[0])  # base는 에피소드마다 교체됨
 
     # ── Stage 1: 단일 duty (overnight 없음) ──────────────────────────
     # max_duty_periods=1 → END_DUTY 불가 → 당일 connection만 학습
-    stage1_c = {**base, "max_duty_periods": 1, "max_pairing_days": 1}
-    run_curriculum_stage(1, flights, encoder, decoder, optimizer,
-                         origins, dests, dep_times, arr_times,
+    stage1_c = {**base_constraint, "max_duty_periods": 1, "max_pairing_days": 1}
+    run_curriculum_stage(1, encoder, decoder, optimizer,
                          n_episodes=1000, constraint_override=stage1_c,
-                         save_dir=save_dir)
+                         save_dir=save_dir, flight_sampler=flight_sampler)
 
     # ── Stage 2: full multi-day ───────────────────────────────────────
     # overnight connection 포함 전체 multi-day pairing 학습
-    stage2_c = {**base, "max_duty_periods": 4, "max_pairing_days": 5}
-    run_curriculum_stage(2, flights, encoder, decoder, optimizer,
-                         origins, dests, dep_times, arr_times,
+    stage2_c = {**base_constraint, "max_duty_periods": 4, "max_pairing_days": 5}
+    run_curriculum_stage(2, encoder, decoder, optimizer,
                          n_episodes=2000, constraint_override=stage2_c,
-                         save_dir=save_dir)
+                         save_dir=save_dir, flight_sampler=flight_sampler)
 
-    # ── Stage 3: constraint 랜덤 augmentation (FiLM 학습) ────────────
-    # 매 에피소드 max_duty를 6~14h 사이 랜덤 샘플링
-    # → FiLM이 constraint 변화에 반응하도록 학습
-    stage3_base = {**base, "max_duty_periods": 4, "max_pairing_days": 5}
+    # ── Stage 3: 7개 constraint 전체 랜덤 augmentation (FiLM 학습) ───
+    # 매 에피소드 7개 constraint 전부 랜덤 샘플링 → FiLM이 다양한 constraint에 적응
+    stage3_base = {**base_constraint, "max_duty_periods": 4, "max_pairing_days": 5}
     def sample_constraint():
-        return {**stage3_base, "max_duty": random.uniform(6.0, 14.0)}
+        return {
+            **stage3_base,
+            "max_duty":         random.uniform(12.0, 14.0),
+            "min_rest":         random.uniform(10.0, 11.0),
+            "min_conn":         random.uniform(0.5,  1.0),
+            "max_conn":         random.uniform(3.0,  4.0),
+            "max_legs":         random.randint(3, 4),
+            "max_duty_periods": random.randint(3, 4),
+            "max_pairing_days": random.randint(3, 5),
+        }
 
-    run_curriculum_stage(3, flights, encoder, decoder, optimizer,
-                         origins, dests, dep_times, arr_times,
+    run_curriculum_stage(3, encoder, decoder, optimizer,
                          n_episodes=2000, constraint_override=stage3_base,
-                         save_dir=save_dir, constraint_sampler=sample_constraint)
+                         save_dir=save_dir, flight_sampler=flight_sampler,
+                         constraint_sampler=sample_constraint)
+
+    # ── TODO: Phase 2 — CG dual feedback ─────────────────────────────
+    # LP relaxation으로 μ[f] (dual variable) 추출 후 RL reward로 피드백
+    # set_partition.py IP 결과를 활용한 양방향 학습 구조
+    # 혜린 set_partition.py 완성 후 구현 예정
 
     # ── FiLM 검증: constraint별 greedy 결과 비교 ─────────────────────
     print()
@@ -338,12 +388,18 @@ def train():
 
     encoder.eval()
     decoder.eval()
+    # 검증용 고정 데이터 (offset=0, base=ATL)
+    val_flights = load_flights_rolling(DATA_PATH, WINDOW_DAYS, 0, airport_map)
+    val_origins, val_dests, val_dep_times, val_arr_times = flights_to_tensors(val_flights, WINDOW_DAYS)
+    val_base = base_ids[0]
+
     with torch.no_grad():
-        for duty in [6.0, 8.0, 10.0, 12.0, 14.0]:
-            c = {**stage3_base, "max_duty": duty}
-            enc = encoder(origins, dests, dep_times, arr_times, constraint_to_tensor(c))
-            _, _, _, metrics = run_episode(flights, c, encoder, decoder, enc, greedy=True)
-            print(f"  max_duty={duty:4.0f}h → pairings: {metrics['n_pairings']:3d}  "
+        for duty in [12.0, 12.5, 13.0, 13.5, 14.0]:
+            c = {**get_delta_constraints(val_base), "max_duty": duty,
+                 "max_duty_periods": 4, "max_pairing_days": 5}
+            enc = encoder(val_origins, val_dests, val_dep_times, val_arr_times, constraint_to_tensor(c))
+            _, _, _, metrics = run_episode(val_flights, c, encoder, decoder, enc, greedy=True)
+            print(f"  max_duty={duty:4.1f}h → pairings: {metrics['n_pairings']:3d}  "
                   f"deadheads: {metrics['n_deadheads']:3d}  "
                   f"coverage: {metrics['coverage_pct']:5.1f}%")
 
@@ -353,6 +409,8 @@ def train():
         "decoder":        decoder.state_dict(),
         "n_airports":     n_airports,
         "constraint_dim": len(FILM_CONSTRAINT_KEYS),
+        "bases":          DELTA_BASES,
+        "window_days":    WINDOW_DAYS,
     }, os.path.join(save_dir, "model_latest.pt"))
     print(f"\n모델 저장: checkpoints/model_latest.pt")
 

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -589,7 +589,7 @@ def run_curriculum_stage(
     """
     커리큘럼 1단계 실행.
 
-    flight_sampler: () → (flights, origins, dests, dep_times, arr_times, base_airport)
+    flight_sampler: () → (flights, origins, dests, dep_times, arr_times, fly_times, base_airport)
                     에피소드마다 호출 — (base, window) 쌍 랜덤 선택 + flight 로드
     constraint_sampler: () → constraint dict. None이면 constraint_override 고정 사용.
     """

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -112,23 +112,29 @@ def run_episode(flights, constraint, encoder, decoder, encoded, greedy=False):
         mask_list = get_mask(state, flights, assigned, constraint)
         mask = torch.tensor(mask_list, dtype=torch.float32)
 
-        # flight도 없고 END_DUTY도 불가 → 다음 미배정 flight로 강제 이동
-        no_flight = sum(mask_list[:-2]) == 0
-        no_end_duty = mask_list[-2] == 0
-        if no_flight and no_end_duty:
-            # pairing_start=False (진행 중 막힌 경우)만 deadhead 패널티
-            if not state.get("pairing_start", False):
-                n_pairings += 1
-                n_deadheads += 1
-                if state["current_airport"] != constraint["base_airport"]:
-                    total_reward -= BASE_PENALTY
-                total_reward -= PAIRING_COST
-
+        # flight도 없고 END_DUTY/END_PAIRING도 불가 → 강제로 새 pairing 시작 (deadhead)
+        no_flight     = sum(mask_list[:-2]) == 0
+        no_end_duty   = mask_list[-2] == 0
+        no_end_pairing = mask_list[-1] == 0
+        if no_flight and no_end_duty and no_end_pairing:
             unassigned = [f for f in flights if not assigned[f["id"]]]
             if len(unassigned) == 0:
                 break
 
-            earliest = sorted(unassigned, key=lambda x: x["dep_time"])[0]
+            # base 출발 편 우선, 없으면 가장 이른 편으로 강제 이동 (deadhead)
+            base = constraint["base_airport"]
+            base_unassigned = [f for f in unassigned if f["origin"] == base]
+            earliest = sorted(base_unassigned or unassigned, key=lambda x: x["dep_time"])[0]
+
+            if not state.get("pairing_start", False):
+                n_pairings += 1
+                n_deadheads += 1
+                # BASE_PENALTY, PAIRING_COST는 environment step()과 중복되지 않도록
+                # deadhead 강제이동 시에만 직접 차감
+                total_reward -= config.DEFAULT_CONSTRAINTS["pairing_cost"]
+                if state["current_airport"] != base:
+                    total_reward -= config.DEFAULT_CONSTRAINTS["base_penalty"]
+
             state = {
                 "current_airport":    earliest["origin"],
                 "current_time":       earliest["dep_time"],
@@ -159,51 +165,29 @@ def run_episode(flights, constraint, encoder, decoder, encoded, greedy=False):
 
         n_flights = len(flights)
 
-        # END_DUTY (index N): 현재 duty 종료 → rest period 진입
+        # END_DUTY (index N): step()이 rest 진입 처리
         if action == n_flights:
-            state = step_end_duty(state, constraint)
-            total_reward -= OVERNIGHT_PENALTY
+            state, r, done = step(state, action, flights, assigned, constraint)
+            total_reward += r
             continue
 
-        # END_PAIRING (index N+1): pairing 전체 종료
+        # END_PAIRING (index N+1): step()이 BASE_PENALTY + PAIRING_COST 처리
         if action == n_flights + 1:
             n_pairings += 1
-
-            if state["current_airport"] != constraint["base_airport"]:
-                total_reward -= BASE_PENALTY
-            total_reward -= PAIRING_COST
-
-            unassigned = [f for f in flights if not assigned[f["id"]]]
-            if len(unassigned) == 0:
+            state, r, done = step(state, action, flights, assigned, constraint)
+            total_reward += r
+            if done:
                 break
-
-            earliest = sorted(unassigned, key=lambda x: x["dep_time"])[0]
-            state = {
-                "current_airport":    earliest["origin"],
-                "current_time":       earliest["dep_time"],
-                "duty_time":          0.0,
-                "duty_start_time":    earliest["dep_time"],
-                "legs":               0,
-                "remaining":          sum(1 for v in assigned.values() if not v),
-                "pairing_start":      True,
-                "duty_period":        0,
-                "pairing_start_time": earliest["dep_time"],
-                "is_resting":         False,
-                "rest_end_time":      None,
-            }
             continue
 
         # flight action
-        prev_legs = state.get("legs", 0)
         state, r, done = step(state, action, flights, assigned, constraint)
         total_reward += r
-        if prev_legs >= 1:              # 2번째 leg부터 보너스 (연결 장려)
-            total_reward += LEG_BONUS
 
         if done:
             break
 
-    total_reward += final_reward(assigned, uncovered_penalty=UNCOVERED_PENALTY)
+    total_reward += final_reward(assigned)
 
     n_uncovered = sum(1 for v in assigned.values() if not v)
     coverage_pct = (len(flights) - n_uncovered) / len(flights) * 100

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -16,10 +16,11 @@ import torch.optim as optim
 from torch.distributions import Categorical
 
 from model import FlightEncoder, PointerDecoder
-from loader import load_flights, load_flights_multiday
-from environment import get_mask, step, step_end_duty, final_reward, END_DUTY
+from loader import build_airport_map, bases_to_ids, load_flights_rolling
+from environment import get_mask, step, final_reward
 from constraints import get_delta_constraints, FILM_CONSTRAINT_KEYS
 from state import init_state
+import config
 
 PAIRING_COST      = 5.0   # pairing 완성/강제종료 시 -5 (deadhead 억제)
 BASE_PENALTY      = 5.0   # base 미복귀 시 -5 (feasibility 강제)

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -798,6 +798,7 @@ def train():
         "constraint_dim": len(FILM_CONSTRAINT_KEYS),
         "bases":          airline_bases,
         "window_days":    WINDOW_DAYS,
+        "max_time":       WINDOW_DAYS * 24,  # evaluate_ip.py가 ckpt["max_time"]으로 직접 읽음
     }, os.path.join(save_dir, "model_latest.pt"))
     print(f"\n모델 저장: checkpoints/model_latest.pt")
 

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -384,13 +384,16 @@ def _collect_pool(flights, constraint, encoder, decoder, encoded, n_rollouts):
     return list(pool.values())
 
 
-def run_episode_with_dual(flights, constraint, encoder, decoder, encoded, dual_vars):
+def run_episode_with_dual(flights, constraint, encoder, decoder, encoded, dual_vars, greedy=False):
     """
     Phase 2 전용 run_episode — flight 배정 시 LP dual variable π[f]를 reward에 추가.
 
     π[f] > 0: LP에서 이 flight 커버 가치 높음 → RL이 적극적으로 포함하도록 유도
     π[f] ≈ 0: 이미 여러 pairing이 커버 → 굳이 포함 안 해도 됨
     dual_vars: {flight_id: π[f]} — solve_lp_relaxation()["dual_vars"]
+
+    greedy=True: stochastic 샘플링 없이 argmax 선택 (baseline 계산용)
+                 stochastic/greedy 모두 동일한 dual_vars 적용 → advantage가 순수 policy 차이만 반영
     """
     assigned = {f["id"]: False for f in flights}
     state    = init_state(flights, constraint)
@@ -445,11 +448,14 @@ def run_episode_with_dual(flights, constraint, encoder, decoder, encoded, dual_v
 
         state_vec = state_to_vec(state, encoder, constraint)
         probs     = decoder(encoded, state_vec, mask)
-        dist      = Categorical(probs)
-        a         = dist.sample()
-        log_probs.append(dist.log_prob(a))
-        entropies.append(dist.entropy())
-        action = a.item()
+        if greedy:
+            action = probs.argmax().item()
+        else:
+            dist = Categorical(probs)
+            a    = dist.sample()
+            log_probs.append(dist.log_prob(a))
+            entropies.append(dist.entropy())
+            action = a.item()
 
         n_flights = len(flights)
 
@@ -538,8 +544,8 @@ def run_phase2(encoder, decoder, optimizer, n_episodes, constraint, save_dir, fl
 
         with torch.no_grad():
             encoded_g = encoder(origins, dests, dep_times, arr_times, fly_times, c_tensor)
-            reward_g, _, _, metrics_g = run_episode(
-                flights, c, encoder, decoder, encoded_g, greedy=True
+            reward_g, _, _, metrics_g = run_episode_with_dual(
+                flights, c, encoder, decoder, encoded_g, dual_vars, greedy=True
             )
 
         greedy_pairings.append(metrics_g["n_pairings"])

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -670,9 +670,7 @@ def run_curriculum_stage(
 
 def train():
     DATA_PATH   = "RL/data/T_ONTIME_MARKETING.csv"
-    # TODO: 협의 필요 — 우선 max_pairing_days=4(Delta CBA) 기준으로 4일 설정
-    # window가 pairing 최대 기간과 맞아야 한 에피소드 안에서 완성된 pairing 학습 가능
-    WINDOW_DAYS = 4
+    WINDOW_DAYS = config.WINDOW_DAYS  # config.py에서 관리 — max_pairing_days 상한과 연동
 
     # 항공사 base 설정 — config.py에서 AIRLINE 바꾸면 자동 반영
     airline_bases = config.AIRLINE_BASES[config.AIRLINE]
@@ -783,7 +781,7 @@ def train():
     with torch.no_grad():
         for duty in [12.0, 12.5, 13.0, 13.5, 14.0]:
             c = {**get_delta_constraints(val_base), "max_duty": duty,
-                 "max_duty_periods": 4, "max_pairing_days": 5}
+                 "max_duty_periods": 4, "max_pairing_days": WINDOW_DAYS}
             enc = encoder(val_origins, val_dests, val_dep_times, val_arr_times, val_fly_times, constraint_to_tensor(c))
             _, _, _, metrics = run_episode(val_flights, c, encoder, decoder, enc, greedy=True)
             print(f"  max_duty={duty:4.1f}h → pairings: {metrics['n_pairings']:3d}  "

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -28,12 +28,17 @@ def constraint_to_tensor(constraint):
     """constraint dict → FiLM 입력 tensor"""
     return torch.tensor([constraint[k] for k in FILM_CONSTRAINT_KEYS], dtype=torch.float32)
 
-def flights_to_tensors(flights):
-    """혜린 flight dict → 찬주 encoder 입력 tensor 변환"""
+def flights_to_tensors(flights, window_days=5):
+    """혜린 flight dict → 찬주 encoder 입력 tensor 변환
+
+    dep/arr_time을 window_days * 24 기준으로 정규화.
+    encoder.py가 정규화된 시간값을 받도록 설계되어 있음.
+    """
     origins = torch.tensor([f["origin"] for f in flights])
     dests = torch.tensor([f["dest"] for f in flights])
-    dep_times = torch.tensor([f["dep_time"] for f in flights], dtype=torch.float32)
-    arr_times = torch.tensor([f["arr_time"] for f in flights], dtype=torch.float32)
+    max_time = window_days * 24.0
+    dep_times = torch.tensor([f["dep_time"] / max_time for f in flights], dtype=torch.float32)
+    arr_times = torch.tensor([f["arr_time"] / max_time for f in flights], dtype=torch.float32)
     return origins, dests, dep_times, arr_times
 
 

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -22,11 +22,6 @@ from constraints import get_delta_constraints, FILM_CONSTRAINT_KEYS
 from state import init_state
 import config
 
-PAIRING_COST      = 5.0   # pairing 완성/강제종료 시 -5 (deadhead 억제)
-BASE_PENALTY      = 5.0   # base 미복귀 시 -5 (feasibility 강제)
-UNCOVERED_PENALTY = 10.0  # 미배정 flight당 -10 (coverage 강제)
-OVERNIGHT_PENALTY = 0.5   # END_DUTY 1회당 -0.5 (overnight rest 허용)
-LEG_BONUS         = 1.5   # 2번째 leg부터 +1.5 (연결 장려)
 
 
 def constraint_to_tensor(constraint):

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -231,12 +231,12 @@ def run_curriculum_stage(
         sample = flight_sampler()
         if sample is None:
             continue
-        flights, origins, dests, dep_times, arr_times, base_airport = sample
+        flights, origins, dests, dep_times, arr_times, fly_times, base_airport = sample
 
         c = constraint_sampler() if constraint_sampler else constraint_override
         c = {**c, "base_airport": base_airport}  # 에피소드별 base 주입
         c_tensor = constraint_to_tensor(c)
-        encoded  = encoder(origins, dests, dep_times, arr_times, c_tensor)
+        encoded  = encoder(origins, dests, dep_times, arr_times, fly_times, c_tensor)
 
         reward_s, log_probs, entropies, metrics_s = run_episode(
             flights, c, encoder, decoder, encoded, greedy=False
@@ -245,7 +245,7 @@ def run_curriculum_stage(
             continue
 
         with torch.no_grad():
-            encoded_g = encoder(origins, dests, dep_times, arr_times, c_tensor)
+            encoded_g = encoder(origins, dests, dep_times, arr_times, fly_times, c_tensor)
             reward_g, _, _, metrics_g = run_episode(
                 flights, c, encoder, decoder, encoded_g, greedy=True
             )
@@ -336,8 +336,8 @@ def train():
         # base 출발 편 없는 window는 스킵 (state.py fallback 방지)
         if not any(f["origin"] == base_airport for f in flights):
             return None
-        origins, dests, dep_times, arr_times = flights_to_tensors(flights, WINDOW_DAYS)
-        return flights, origins, dests, dep_times, arr_times, base_airport
+        origins, dests, dep_times, arr_times, fly_times = flights_to_tensors(flights, WINDOW_DAYS)
+        return flights, origins, dests, dep_times, arr_times, fly_times, base_airport
 
     base_constraint = get_delta_constraints(base_ids[0])  # base는 에피소드마다 교체됨
 
@@ -395,14 +395,14 @@ def train():
     decoder.eval()
     # 검증용 고정 데이터 (offset=0, base=ATL)
     val_flights = load_flights_rolling(DATA_PATH, WINDOW_DAYS, 0, airport_map)
-    val_origins, val_dests, val_dep_times, val_arr_times = flights_to_tensors(val_flights, WINDOW_DAYS)
+    val_origins, val_dests, val_dep_times, val_arr_times, val_fly_times = flights_to_tensors(val_flights, WINDOW_DAYS)
     val_base = base_ids[0]
 
     with torch.no_grad():
         for duty in [12.0, 12.5, 13.0, 13.5, 14.0]:
             c = {**get_delta_constraints(val_base), "max_duty": duty,
                  "max_duty_periods": 4, "max_pairing_days": 5}
-            enc = encoder(val_origins, val_dests, val_dep_times, val_arr_times, constraint_to_tensor(c))
+            enc = encoder(val_origins, val_dests, val_dep_times, val_arr_times, val_fly_times, constraint_to_tensor(c))
             _, _, _, metrics = run_episode(val_flights, c, encoder, decoder, enc, greedy=True)
             print(f"  max_duty={duty:4.1f}h → pairings: {metrics['n_pairings']:3d}  "
                   f"deadheads: {metrics['n_deadheads']:3d}  "

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -203,6 +203,384 @@ def run_episode(flights, constraint, encoder, decoder, encoded, greedy=False):
     return total_reward, log_probs, entropies, metrics
 
 
+# ── Phase 2 helpers ──────────────────────────────────────────────────────────
+"""
+phase2는 LP dual variable을 RL reward에 피드백하는 구조임. 
+이를 위해 4개 함수가 필요함
+1. pairing 구조체를 수집하는 rollout 함수 
+2. 중복 제거 pool 수집 함수 
+3. dual feedback이 포함된 에피소드 함수
+4. Phase 2 학습 루프
+"""
+# evaluate_ip.py의 rollout_with_pairings()를 참고해 train.py 내부 함수로 구현.
+
+# pairing cost = dead_time - LEG_BONUS*(n_legs-1) + DEADHEAD_PENALTY*(강제종료여부)
+# dead_time: 실제 비행 외 대기 시간 (elapsed - fly - rest)
+# LEG_BONUS: leg 추가될수록 cost 감소 → 효율적 연결 장려
+# DEADHEAD_PENALTY: 강제 deadhead 발생 시 가산
+_LEG_BONUS_IP        = 1.5
+_DEADHEAD_PENALTY_IP = 5.0
+
+
+def _rollout_with_pairings(flights, constraint, encoder, decoder, encoded, greedy=False):
+    """
+    run_episode()와 동일한 rollout이지만 pairing 구조체(legs, cost 등)를 반환.
+    LP relaxation에 넣을 pool 수집 전용. gradient 추적 불필요 → no_grad 하에서 호출.
+
+    feat/ip-multibase evaluate_ip.py의 rollout_with_pairings() 참고.
+    """
+    assigned = {f["id"]: False for f in flights}
+    pairings = []
+
+    current_legs     = []
+    pairing_dep      = None
+    pairing_fly      = 0.0
+    pairing_last_arr = 0.0
+    pairing_rest     = 0.0
+
+    def flush_pairing(is_forced=False):
+        if len(current_legs) < 1 or pairing_dep is None:
+            return
+        elapsed   = pairing_last_arr - pairing_dep
+        dead_time = max(elapsed - pairing_fly - pairing_rest, 0.0)
+        cost      = (dead_time
+                     - _LEG_BONUS_IP * max(len(current_legs) - 1, 0)
+                     + (_DEADHEAD_PENALTY_IP if is_forced else 0.0))
+        pairings.append({"legs": list(current_legs), "fly": pairing_fly,
+                         "elapsed": elapsed, "cost": cost})
+
+    def start_new(f):
+        nonlocal pairing_dep, pairing_fly, pairing_last_arr, pairing_rest
+        current_legs.clear()
+        current_legs.append(f["id"])
+        pairing_dep      = f["dep_time"]
+        pairing_fly      = f["arr_time"] - f["dep_time"]
+        pairing_last_arr = f["arr_time"]
+        pairing_rest     = 0.0
+
+    episode_base = constraint.get("base_airport", 0)
+
+    # 첫 flight 수동 시작 — base 출발 편 우선
+    unassigned   = [f for f in flights if not assigned[f["id"]]]
+    base_flights = [f for f in unassigned if f["origin"] == episode_base]
+    first        = sorted(base_flights or unassigned, key=lambda f: f["dep_time"])[0]
+    assigned[first["id"]] = True
+    start_new(first)
+    state = {
+        "current_airport":    first["dest"],
+        "current_time":       first["arr_time"],
+        "duty_time":          first["arr_time"] - first["dep_time"],
+        "duty_start_time":    first["dep_time"],
+        "legs":               1,
+        "remaining":          sum(1 for v in assigned.values() if not v),
+        "pairing_start":      False,
+        "duty_period":        0,
+        "pairing_start_time": first["dep_time"],
+        "is_resting":         False,
+        "rest_end_time":      None,
+    }
+
+    max_steps  = len(flights) * 20
+    step_count = 0
+
+    while True:
+        step_count += 1
+        if step_count > max_steps:
+            flush_pairing(is_forced=False)
+            break
+
+        mask_list = get_mask(state, flights, assigned, constraint)
+        mask      = torch.tensor(mask_list, dtype=torch.float32)
+
+        # mask 전부 0 → 강제 deadhead
+        if sum(mask_list[:-2]) == 0 and mask_list[-2] == 0 and mask_list[-1] == 0:
+            unassigned = [f for f in flights if not assigned[f["id"]]]
+            if not unassigned:
+                flush_pairing(is_forced=False)
+                break
+            flush_pairing(is_forced=True)
+            base_flights = [f for f in unassigned if f["origin"] == episode_base]
+            nxt = sorted(base_flights or unassigned, key=lambda f: f["dep_time"])[0]
+            assigned[nxt["id"]] = True
+            start_new(nxt)
+            state = {
+                "current_airport":    nxt["dest"],
+                "current_time":       nxt["arr_time"],
+                "duty_time":          nxt["arr_time"] - nxt["dep_time"],
+                "duty_start_time":    nxt["dep_time"],
+                "legs":               1,
+                "remaining":          sum(1 for v in assigned.values() if not v),
+                "pairing_start":      False,
+                "duty_period":        0,
+                "pairing_start_time": nxt["dep_time"],
+                "is_resting":         False,
+                "rest_end_time":      None,
+            }
+            continue
+
+        state_vec = state_to_vec(state, encoder, constraint)
+        probs     = decoder(encoded, state_vec, mask)
+        action    = probs.argmax().item() if greedy else Categorical(probs).sample().item()
+
+        if action == len(flights):          # END_DUTY
+            pairing_rest += constraint.get("min_rest", 9.5)
+            state, _, _ = step(state, action, flights, assigned, constraint)
+            continue
+
+        if action == len(flights) + 1:      # END_PAIRING → 새 pairing 시작
+            flush_pairing(is_forced=False)
+            unassigned = [f for f in flights if not assigned[f["id"]]]
+            if not unassigned:
+                break
+            base_flights = [f for f in unassigned if f["origin"] == episode_base]
+            nxt = sorted(base_flights or unassigned, key=lambda f: f["dep_time"])[0]
+            assigned[nxt["id"]] = True
+            start_new(nxt)
+            state = {
+                "current_airport":    nxt["dest"],
+                "current_time":       nxt["arr_time"],
+                "duty_time":          nxt["arr_time"] - nxt["dep_time"],
+                "duty_start_time":    nxt["dep_time"],
+                "legs":               1,
+                "remaining":          sum(1 for v in assigned.values() if not v),
+                "pairing_start":      False,
+                "duty_period":        0,
+                "pairing_start_time": nxt["dep_time"],
+                "is_resting":         False,
+                "rest_end_time":      None,
+            }
+            continue
+
+        # flight action — pairing에 leg 추가
+        f = flights[action]
+        current_legs.append(f["id"])
+        pairing_fly      += f["arr_time"] - f["dep_time"]
+        pairing_last_arr  = f["arr_time"]
+        state, _, done = step(state, action, flights, assigned, constraint)
+        if done:
+            flush_pairing(is_forced=False)
+            break
+
+    return pairings
+
+
+def _collect_pool(flights, constraint, encoder, decoder, encoded, n_rollouts):
+    """
+    stochastic rollout × n_rollouts + greedy rollout × 1 → 중복 제거 pairing pool.
+    중복 기준: legs 집합이 동일하면 cost가 낮은 쪽 유지.
+    pool은 solve_lp_relaxation()의 입력으로 사용된다.
+    """
+    pool = {}
+    for _ in range(n_rollouts):
+        for p in _rollout_with_pairings(flights, constraint, encoder, decoder, encoded):
+            key = tuple(sorted(p["legs"]))
+            if key not in pool or p["cost"] < pool[key]["cost"]:
+                pool[key] = p
+    # greedy 1번 추가 — 실현 가능한 고품질 pairing 항상 보장
+    for p in _rollout_with_pairings(flights, constraint, encoder, decoder, encoded, greedy=True):
+        key = tuple(sorted(p["legs"]))
+        if key not in pool or p["cost"] < pool[key]["cost"]:
+            pool[key] = p
+    return list(pool.values())
+
+
+def run_episode_with_dual(flights, constraint, encoder, decoder, encoded, dual_vars):
+    """
+    Phase 2 전용 run_episode — flight 배정 시 LP dual variable π[f]를 reward에 추가.
+
+    π[f] > 0: LP에서 이 flight 커버 가치 높음 → RL이 적극적으로 포함하도록 유도
+    π[f] ≈ 0: 이미 여러 pairing이 커버 → 굳이 포함 안 해도 됨
+    dual_vars: {flight_id: π[f]} — solve_lp_relaxation()["dual_vars"]
+    """
+    assigned = {f["id"]: False for f in flights}
+    state    = init_state(flights, constraint)
+
+    log_probs    = []
+    entropies    = []
+    total_reward = 0
+    n_pairings   = 0
+    n_deadheads  = 0
+    base         = constraint["base_airport"]
+
+    max_steps  = len(flights) * 20
+    step_count = 0
+
+    while True:
+        step_count += 1
+        if step_count > max_steps:
+            break
+
+        mask_list  = get_mask(state, flights, assigned, constraint)
+        mask       = torch.tensor(mask_list, dtype=torch.float32)
+
+        no_flight      = sum(mask_list[:-2]) == 0
+        no_end_duty    = mask_list[-2] == 0
+        no_end_pairing = mask_list[-1] == 0
+        if no_flight and no_end_duty and no_end_pairing:
+            unassigned = [f for f in flights if not assigned[f["id"]]]
+            if not unassigned:
+                break
+            base_unassigned = [f for f in unassigned if f["origin"] == base]
+            earliest = sorted(base_unassigned or unassigned, key=lambda x: x["dep_time"])[0]
+            if not state.get("pairing_start", False):
+                n_pairings  += 1
+                n_deadheads += 1
+                total_reward -= config.DEFAULT_CONSTRAINTS["pairing_cost"]
+                if state["current_airport"] != base:
+                    total_reward -= config.DEFAULT_CONSTRAINTS["base_penalty"]
+            state = {
+                "current_airport":    earliest["origin"],
+                "current_time":       earliest["dep_time"],
+                "duty_time":          0.0,
+                "duty_start_time":    earliest["dep_time"],
+                "legs":               0,
+                "remaining":          sum(1 for v in assigned.values() if not v),
+                "pairing_start":      True,
+                "duty_period":        0,
+                "pairing_start_time": earliest["dep_time"],
+                "is_resting":         False,
+                "rest_end_time":      None,
+            }
+            continue
+
+        state_vec = state_to_vec(state, encoder, constraint)
+        probs     = decoder(encoded, state_vec, mask)
+        dist      = Categorical(probs)
+        a         = dist.sample()
+        log_probs.append(dist.log_prob(a))
+        entropies.append(dist.entropy())
+        action = a.item()
+
+        n_flights = len(flights)
+
+        if action == n_flights:         # END_DUTY
+            state, r, done = step(state, action, flights, assigned, constraint)
+            total_reward += r
+            continue
+
+        if action == n_flights + 1:     # END_PAIRING
+            n_pairings += 1
+            state, r, done = step(state, action, flights, assigned, constraint)
+            total_reward += r
+            if done:
+                break
+            continue
+
+        # flight action — π[flight_id] 추가 (CG dual feedback)
+        flight_id = flights[action]["id"]
+        state, r, done = step(state, action, flights, assigned, constraint)
+        total_reward += r + dual_vars.get(flight_id, 0.0)
+        if done:
+            break
+
+    total_reward += final_reward(assigned)
+    n_uncovered  = sum(1 for v in assigned.values() if not v)
+    coverage_pct = (len(flights) - n_uncovered) / len(flights) * 100
+    return total_reward, log_probs, entropies, {
+        "n_pairings":   n_pairings,
+        "n_deadheads":  n_deadheads,
+        "n_uncovered":  n_uncovered,
+        "coverage_pct": coverage_pct,
+    }
+
+
+def run_phase2(encoder, decoder, optimizer, n_episodes, constraint, save_dir, flight_sampler):
+    """
+    Phase 2 — Column Generation dual feedback 학습.
+
+    매 PHASE2_LP_INTERVAL 에피소드마다:
+      1. pool 수집 (_collect_pool, no_grad)
+      2. LP relaxation → dual variable π[f] 추출 (set_partition.solve_lp_relaxation)
+      3. π[f]를 reward에 반영해 REINFORCE 업데이트 (run_episode_with_dual)
+
+    set_partition.py는 혜린 담당 — import만 사용, 파일 수정 없음.
+    """
+    from set_partition import solve_lp_relaxation
+
+    params            = list(encoder.parameters()) + list(decoder.parameters())
+    best_avg_pairings = float("inf")
+    greedy_pairings   = []
+    dual_vars         = {}  # {flight_id: π[f]}, LP interval마다 갱신, 사이에는 캐싱
+
+    print(f"\n{'='*60}")
+    print(f"Phase 2: CG dual feedback  "
+          f"(LP interval={config.PHASE2_LP_INTERVAL}, "
+          f"pool rollouts={config.PHASE2_POOL_ROLLOUTS})")
+    print(f"{'='*60}")
+
+    for ep in range(n_episodes):
+        sample = flight_sampler()
+        if sample is None:
+            continue
+        flights, origins, dests, dep_times, arr_times, fly_times, base_airport = sample
+
+        c        = {**constraint, "base_airport": base_airport}
+        c_tensor = constraint_to_tensor(c)
+
+        with torch.no_grad():
+            encoded = encoder(origins, dests, dep_times, arr_times, fly_times, c_tensor)
+
+            # LP interval마다 pool 수집 → LP relaxation → dual vars 갱신
+            if ep % config.PHASE2_LP_INTERVAL == 0:
+                pool      = _collect_pool(flights, c, encoder, decoder, encoded,
+                                          n_rollouts=config.PHASE2_POOL_ROLLOUTS)
+                lp_result = solve_lp_relaxation(pool)
+                if lp_result is not None:
+                    dual_vars = lp_result["dual_vars"]  # {flight_id: π[f]}
+
+        # dual feedback 포함 REINFORCE
+        encoded_train = encoder(origins, dests, dep_times, arr_times, fly_times, c_tensor)
+        reward_s, log_probs, entropies, metrics_s = run_episode_with_dual(
+            flights, c, encoder, decoder, encoded_train, dual_vars
+        )
+        if len(log_probs) == 0:
+            continue
+
+        with torch.no_grad():
+            encoded_g = encoder(origins, dests, dep_times, arr_times, fly_times, c_tensor)
+            reward_g, _, _, metrics_g = run_episode(
+                flights, c, encoder, decoder, encoded_g, greedy=True
+            )
+
+        greedy_pairings.append(metrics_g["n_pairings"])
+        advantage = (reward_s - reward_g) / (abs(reward_g) + 1e-6)
+
+        loss = torch.stack([
+            -lp * advantage - 0.01 * ent
+            for lp, ent in zip(log_probs, entropies)
+        ]).sum()
+
+        optimizer.zero_grad()
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(params, max_norm=1.0)
+        optimizer.step()
+
+        if len(greedy_pairings) >= 25:
+            recent_avg = sum(greedy_pairings[-25:]) / 25
+            if recent_avg < best_avg_pairings:
+                best_avg_pairings = recent_avg
+                torch.save({
+                    "encoder":           encoder.state_dict(),
+                    "decoder":           decoder.state_dict(),
+                    "stage":             "phase2",
+                    "episode":           ep,
+                    "best_avg_pairings": best_avg_pairings,
+                }, os.path.join(save_dir, "phase2_best.pt"))
+
+        if ep % 25 == 0:
+            avg25 = sum(greedy_pairings[-25:]) / len(greedy_pairings[-25:])
+            print(
+                f"  Ep {ep:4d} | "
+                f"sample: p={metrics_s['n_pairings']:3d} dh={metrics_s['n_deadheads']:3d} | "
+                f"greedy: p={metrics_g['n_pairings']:3d} (avg25={avg25:5.1f}) | "
+                f"adv: {advantage:6.3f} | dual keys: {len(dual_vars)}"
+            )
+
+    print(f"  → best avg pairings: {best_avg_pairings:.1f}  "
+          f"(saved: checkpoints/phase2_best.pt)")
+    return best_avg_pairings
+
+
 def run_curriculum_stage(
     stage, encoder, decoder, optimizer,
     n_episodes, constraint_override, save_dir,
@@ -380,10 +758,14 @@ def train():
                          save_dir=save_dir, flight_sampler=flight_sampler,
                          constraint_sampler=sample_constraint)
 
-    # ── TODO: Phase 2 — CG dual feedback ─────────────────────────────
-    # LP relaxation으로 μ[f] (dual variable) 추출 후 RL reward로 피드백
-    # set_partition.py IP 결과를 활용한 양방향 학습 구조
-    # 혜린 set_partition.py 완성 후 구현 예정
+    # ── Phase 2: CG dual feedback ──────────────────────────────────────
+    # Stage 3 이후 동일 모델 이어서 학습 (Phase 1 → Phase 2 연속)
+    phase2_c = {**base_constraint, "max_duty_periods": 4, "max_pairing_days": WINDOW_DAYS}
+    run_phase2(encoder, decoder, optimizer,
+               n_episodes=config.PHASE2_N_EPISODES,
+               constraint=phase2_c,
+               save_dir=save_dir,
+               flight_sampler=flight_sampler)
 
     # ── FiLM 검증: constraint별 greedy 결과 비교 ─────────────────────
     print()

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -43,23 +43,44 @@ def flights_to_tensors(flights, window_days=5):
 
 
 def state_to_vec(state, encoder, constraint):
-    """혜린 state dict → 찬주 decoder 입력 tensor 변환"""
-    airport_emb = encoder.airport_emb(torch.tensor(state["current_airport"]))
+    """혜린 state dict → 찬주 decoder 입력 tensor 변환
+
+    state_vec(71,) = current_emb(32) + base_emb(32) + scalars(7)
+    7개 스칼라: time_of_day, day_norm, duty_elapsed/max, legs/max, duty_period/max, is_resting, rest_remaining
+    """
+    current_emb = encoder.airport_emb(torch.tensor(state["current_airport"]))
+    base_emb    = encoder.airport_emb(torch.tensor(constraint["base_airport"]))
 
     max_pairing_days = constraint.get("max_pairing_days", 5)
-    time_of_day  = (state["current_time"] % 24.0) / 24.0
-    day_norm     = (state["current_time"] // 24.0) / max(max_pairing_days, 1)
+    time_of_day      = (state["current_time"] % 24.0) / 24.0
+    day_norm         = (state["current_time"] // 24.0) / max(max_pairing_days, 1)
     duty_period_norm = state.get("duty_period", 0) / max(constraint.get("max_duty_periods", 4), 1)
 
+    # duty_elapsed: 비행 시간만이 아닌 FAA 기준 실제 경과 시간 (비행 + 대기)
+    # is_resting/pairing_start 중이면 새 duty 아직 시작 안 함 → 0
+    if state.get("is_resting", False) or state.get("pairing_start", False):
+        duty_elapsed = 0.0
+    else:
+        duty_elapsed = max(0.0, state["current_time"] - state.get("duty_start_time", state["current_time"]))
+
+    # rest_remaining: is_resting=True일 때 남은 rest 시간 비율 (0~1), 아니면 0.0
+    min_rest = constraint.get("min_rest", 10.0)
+    if state.get("is_resting", False) and state.get("rest_end_time") is not None:
+        rest_remaining = max(0.0, state["rest_end_time"] - state["current_time"]) / min_rest
+    else:
+        rest_remaining = 0.0
+
     return torch.cat([
-        airport_emb,
+        current_emb,
+        base_emb,
         torch.tensor([
             time_of_day,
             day_norm,
-            state["duty_time"] / constraint["max_duty"],
+            duty_elapsed / constraint["max_duty"],
             state["legs"] / constraint["max_legs"],
             duty_period_norm,
             1.0 if state.get("is_resting", False) else 0.0,
+            rest_remaining,
         ], dtype=torch.float32)
     ])
 

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -1,11 +1,3 @@
-"""
-찬주 model/ + 혜린 RL/environment 통합 학습 스크립트
-- encoder: 찬주 (FlightEncoder — Embedding + FiLM + Transformer)
-- decoder: 찬주 (PointerDecoder — Pointer Attention + hard masking)
-- environment: 혜린 (mask + step + reward)
-- loader: 혜린 (BTS CSV → flight dict)
-"""
-
 import os
 import sys
 import random
@@ -294,17 +286,15 @@ def train():
     # window가 pairing 최대 기간과 맞아야 한 에피소드 안에서 완성된 pairing 학습 가능
     WINDOW_DAYS = 4
 
-    # TODO(loader PR #10 머지 후): bases_to_ids()는 loader.py에서 import해서 사용
-    # 현재는 loader PR #10이 미머지 상태라 build_airport_map + bases_to_ids 직접 호출
-    # DELTA_BASES: 연구자가 도메인 지식으로 직접 입력하는 crew base 목록
-    DELTA_BASES = ["ATL", "DTW", "MSP", "JFK", "LAX"]
+    # 항공사 base 설정 — config.py에서 AIRLINE 바꾸면 자동 반영
+    airline_bases = config.AIRLINE_BASES[config.AIRLINE]
 
     # 전체 CSV 기준 공항 ID 고정 (에피소드 간 ID 일관성 보장)
     airport_map = build_airport_map(DATA_PATH)
-    base_ids    = bases_to_ids(DELTA_BASES, airport_map)
+    base_ids    = bases_to_ids(airline_bases, airport_map)
     n_airports  = len(airport_map)
 
-    print(f"airports: {n_airports}개, bases: {DELTA_BASES}")
+    print(f"airports: {n_airports}개, airline: {config.AIRLINE}, bases: {airline_bases}")
 
     encoder = FlightEncoder(
         n_airports=n_airports,

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -17,8 +17,15 @@ import config
 
 
 def constraint_to_tensor(constraint):
-    """constraint dict → FiLM 입력 tensor"""
-    return torch.tensor([constraint[k] for k in FILM_CONSTRAINT_KEYS], dtype=torch.float32)
+    """constraint dict → FiLM 입력 tensor (정규화 적용)
+
+    정규화 기준값은 config.CONSTRAINT_NORMS에서 관리.
+    evaluate_ip.py도 동일한 값을 써야 checkpoint 호환됨.
+    """
+    return torch.tensor(
+        [constraint[k] / config.CONSTRAINT_NORMS[k] for k in FILM_CONSTRAINT_KEYS],
+        dtype=torch.float32,
+    )
 
 def flights_to_tensors(flights, window_days=5):
     """혜린 flight dict → 찬주 encoder 입력 tensor 변환

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -23,15 +23,18 @@ def constraint_to_tensor(constraint):
 def flights_to_tensors(flights, window_days=5):
     """혜린 flight dict → 찬주 encoder 입력 tensor 변환
 
-    dep/arr_time을 window_days * 24 기준으로 정규화.
-    encoder.py가 정규화된 시간값을 받도록 설계되어 있음.
+    dep/arr/fly_time을 window_days * 24 기준으로 정규화.
+    fly_time = arr - dep (비행 시간) — encoder input_dim이 airport_emb*2 + 3이므로 필수.
     """
     origins = torch.tensor([f["origin"] for f in flights])
     dests = torch.tensor([f["dest"] for f in flights])
     max_time = window_days * 24.0
-    dep_times = torch.tensor([f["dep_time"] / max_time for f in flights], dtype=torch.float32)
-    arr_times = torch.tensor([f["arr_time"] / max_time for f in flights], dtype=torch.float32)
-    return origins, dests, dep_times, arr_times
+    dep_raw = torch.tensor([f["dep_time"] for f in flights], dtype=torch.float32)
+    arr_raw = torch.tensor([f["arr_time"] for f in flights], dtype=torch.float32)
+    dep_times = dep_raw / max_time
+    arr_times = arr_raw / max_time
+    fly_times = (arr_raw - dep_raw) / max_time
+    return origins, dests, dep_times, arr_times, fly_times
 
 
 def state_to_vec(state, encoder, constraint):

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -340,14 +340,16 @@ def train():
 
     # ── Stage 2: full multi-day ───────────────────────────────────────
     # overnight connection 포함 전체 multi-day pairing 학습
-    stage2_c = {**base_constraint, "max_duty_periods": 4, "max_pairing_days": 5}
+    # max_pairing_days를 WINDOW_DAYS로 제한 — window 밖 pairing은 데이터 없어 deadhead만 유발
+    stage2_c = {**base_constraint, "max_duty_periods": 4, "max_pairing_days": WINDOW_DAYS}
     run_curriculum_stage(2, encoder, decoder, optimizer,
                          n_episodes=2000, constraint_override=stage2_c,
                          save_dir=save_dir, flight_sampler=flight_sampler)
 
     # ── Stage 3: 7개 constraint 전체 랜덤 augmentation (FiLM 학습) ───
     # 매 에피소드 7개 constraint 전부 랜덤 샘플링 → FiLM이 다양한 constraint에 적응
-    stage3_base = {**base_constraint, "max_duty_periods": 4, "max_pairing_days": 5}
+    # max_pairing_days 상한도 WINDOW_DAYS로 제한 (config.STAGE3_CONSTRAINT_RANGES 확인)
+    stage3_base = {**base_constraint, "max_duty_periods": 4, "max_pairing_days": WINDOW_DAYS}
     def sample_constraint():
         # 범위는 config.STAGE3_CONSTRAINT_RANGES에서 관리
         # TODO: 범위 확정 후 config.py 범위 수정 

--- a/model/decoder.py
+++ b/model/decoder.py
@@ -20,9 +20,11 @@ class PointerDecoder(nn.Module):
         """
         super().__init__()
 
-        # state_vec(38,) = airport_emb(airport_emb_dim) + 6개 스칼라
+        # state_vec(70,) = current_airport_emb(airport_emb_dim) + base_airport_emb(airport_emb_dim) + 6개 스칼라
         # 6개: time_of_day, day_norm, duty_time/max, legs/max, duty_period/max, is_resting
-        state_input_dim = airport_emb_dim + 6
+        # base_airport_emb 추가 이유: multi-base 설계에서 에피소드마다 base가 달라지므로
+        # 모델이 "이번 에피소드 목표 base가 어디인지" 명시적으로 알아야 복귀 경로 계획 가능
+        state_input_dim = airport_emb_dim * 2 + 6
         self.state_mlp = nn.Sequential(
             nn.Linear(state_input_dim, d_model),
             nn.ReLU(),
@@ -47,14 +49,16 @@ class PointerDecoder(nn.Module):
         encoded_flights: torch.Tensor,
         state_vec: torch.Tensor,
         mask: torch.Tensor,
+        return_logits: bool = False,
     ) -> torch.Tensor:
         """
         Args:
             encoded_flights: (N, d_model)
-            state_vec: (airport_emb_dim+6,)
+            state_vec: (airport_emb_dim*2+6,) — current_emb + base_emb + scalars
             mask: (N+2,) — [...flights, END_DUTY, END_PAIRING]
+            return_logits: True면 softmax 전 raw score 반환 — REINFORCE log_prob 계산 시 수치 안정성
         Returns:
-            probs: (N+2,)
+            probs or logits: (N+2,)
         """
         q = self.state_mlp(state_vec)
         if self.skip_state_mlp:
@@ -70,6 +74,7 @@ class PointerDecoder(nn.Module):
 
         scores = (k @ q) / math.sqrt(self.d_model)  # (N+2,)
         scores[mask == 0] = float('-inf')
-        probs = F.softmax(scores, dim=-1)            # (N+2,)
 
-        return probs
+        if return_logits:
+            return scores                            # (N+2,) — F.log_softmax로 안정적 log_prob 계산
+        return F.softmax(scores, dim=-1)             # (N+2,)

--- a/model/decoder.py
+++ b/model/decoder.py
@@ -20,11 +20,13 @@ class PointerDecoder(nn.Module):
         """
         super().__init__()
 
-        # state_vec(70,) = current_airport_emb(airport_emb_dim) + base_airport_emb(airport_emb_dim) + 6개 스칼라
-        # 6개: time_of_day, day_norm, duty_time/max, legs/max, duty_period/max, is_resting
+        # state_vec(71,) = current_airport_emb(airport_emb_dim) + base_airport_emb(airport_emb_dim) + 7개 스칼라
+        # 7개: time_of_day, day_norm, duty_elapsed/max, legs/max, duty_period/max, is_resting, rest_remaining
         # base_airport_emb 추가 이유: multi-base 설계에서 에피소드마다 base가 달라지므로
         # 모델이 "이번 에피소드 목표 base가 어디인지" 명시적으로 알아야 복귀 경로 계획 가능
-        state_input_dim = airport_emb_dim * 2 + 6
+        # rest_remaining: is_resting=True일 때 (rest_end_time - current_time) / min_rest, 아니면 0.0
+        # TODO(train.py): state_to_vec()에 rest_remaining 스칼라 추가 필요 (6개 → 7개로 맞춰야 함)
+        state_input_dim = airport_emb_dim * 2 + 7
         self.state_mlp = nn.Sequential(
             nn.Linear(state_input_dim, d_model),
             nn.ReLU(),
@@ -54,7 +56,7 @@ class PointerDecoder(nn.Module):
         """
         Args:
             encoded_flights: (N, d_model)
-            state_vec: (airport_emb_dim*2+6,) — current_emb + base_emb + scalars
+            state_vec: (airport_emb_dim*2+7,) — current_emb + base_emb + scalars(7)
             mask: (N+2,) — [...flights, END_DUTY, END_PAIRING]
             return_logits: True면 softmax 전 raw score 반환 — REINFORCE log_prob 계산 시 수치 안정성
         Returns:

--- a/model/decoder.py
+++ b/model/decoder.py
@@ -13,9 +13,15 @@ class PointerDecoder(nn.Module):
     """
 
     def __init__(self, d_model: int = 128, airport_emb_dim: int = 32, skip_state_mlp: bool = False):
+        """
+        d_model: attention 공간 차원 (encoder d_model과 일치해야 함)
+        airport_emb_dim: state_vec 내 공항 embedding 차원 (encoder airport_emb_dim과 일치해야 함)
+        skip_state_mlp: ablation용 — True면 MLP(Linear→ReLU→Linear) 대신 linear projection만 사용
+        """
         super().__init__()
 
-        # state_to_vec: airport_emb(32) + [time_of_day, day_norm, duty_time, legs, duty_period, is_resting] = 38
+        # state_vec(38,) = airport_emb(airport_emb_dim) + 6개 스칼라
+        # 6개: time_of_day, day_norm, duty_time/max, legs/max, duty_period/max, is_resting
         state_input_dim = airport_emb_dim + 6
         self.state_mlp = nn.Sequential(
             nn.Linear(state_input_dim, d_model),


### PR DESCRIPTION
 ## 개요

multi-base + rolling window 파이프라인 설계에 맞게 train.py 전반을 수정했습니다. 항공사 전환 시 config.py 한 줄만 바꾸면 되도록 항공사 설정을  분리하고 feat/ip-multibase encoder 변경 반영 및 Phase 2 CG dual feedback을 구현했습니다.


 ## 변경 내용
                                                                         
  ### train.py    
                       
  #### loader/environment 인터페이스 교체     
  - `load_flights_multiday` → `build_airport_map` + `bases_to_ids` +
  `load_flights_rolling`
  - `step_end_duty()` 제거 → `step()` 하나로 통합                        
                                              
  #### 상수 정리                                                         
  - `PAIRING_COST`, `BASE_PENALTY` 등 → config.py로 이관, 중복 제거
  - `OVERNIGHT_PENALTY`, `LEG_BONUS` → 수정된 reward 설계에 없는 값으로  제거                                        
                                                                         
  #### `flights_to_tensors()` 수정                                       
  - dep/arr_time `window_days * 24` 기준 정규화                          
  - `fly_times` 추가 — encoder input_dim airport_emb×2+3 맞춤 (feat/ip-multibase 반영)                                               
                                          
  #### `constraint_to_tensor()` 정규화 추가   
  - raw값 → `config.CONSTRAINT_NORMS`로 나눠 [0,1] 정규화                
  - evaluate_ip.py와 동일한 값 사용해야 checkpoint 호환
                                                                         
  #### `state_to_vec()` 수정 (38 → 71차원)
  - `base_airport_emb(32)` 추가 — 모델이 에피소드 목표 base 인식         
  - `duty_elapsed` → `current_time - duty_start_time` — FAA 기준 실제 경과 시간                                                              
  - `rest_remaining` 스칼라 추가                                         
                                                                         
  #### `run_episode()` 수정                                              
  - deadhead fallback → base 출발 편 기준으로 수정                       
  - BASE_PENALTY 이중 차감 버그 제거                                     
                                          
  #### `run_curriculum_stage()` 시그니처 변경
  - 고정 flights → `flight_sampler` 함수로 대체                          
  - 에피소드마다 (base, window) 쌍 랜덤 선택  
                                                                         
  #### `train()` 재작성
  - `flight_sampler()`: 에피소드마다 base + offset_days 랜덤, base 출발 편 없는 window 스킵                         
  - Stage 2/3 `max_pairing_days` → `WINDOW_DAYS`(4) 제한 (window 밖 deadhead 방지)                              
  - Stage 3: 7개 constraint 전부 랜덤화 (`config.STAGE3_CONSTRAINT_RANGES` 참조)    
  - Phase 2 CG dual feedback 구현 (아래 참고)                            
  - checkpoint에 `bases`, `window_days`, `max_time` 추가 저장
                                                                         
  #### Phase 2 — CG dual feedback 구현    
  - `_rollout_with_pairings()`: pairing 구조체(legs, cost) 수집 (evaluate_ip.py 참고)
  - `_collect_pool()`: stochastic×30 + greedy×1 rollout → 중복 제거 pool
  - `run_episode_with_dual()`: flight 배정 시 `reward += π[f]` (LP dual variable 피드백)                                                       
  - `run_phase2()`: LP interval(10ep)마다 pool 수집 → `solve_lp_relaxation()` → dual_vars 갱신                               
                                                                         
  ### config.py                                                          
  - `AIRLINE`, `AIRLINE_BASES`: 항공사 전환 시 `AIRLINE` 한 줄만 수정    
  - `CONSTRAINT_NORMS`: FiLM 입력 정규화 기준값
  - `STAGE3_CONSTRAINT_RANGES`: Stage 3 augmentation 범위 (constraint 확정 후 교체 TODO)                                  
  - `PHASE2_POOL_ROLLOUTS=30`, `PHASE2_LP_INTERVAL=10`, `PHASE2_N_EPISODES=1000`                                               
                                                                         
  ---                                                                    
                                                                         
  ## 협의 필요         
  - `WINDOW_DAYS = 4` 확정 여부
  -  base 목록 확정 후 config.py 업데이트 필요
  - `STAGE3_CONSTRAINT_RANGES` 범위값 constraint 확정 후 교체 필요
