### PR TITLE
fix: ftc 계산법 수정

### DIFF
--- a/RL/rollout.py
+++ b/RL/rollout.py
@@ -56,7 +56,8 @@ def rollout_with_pairings(flights, constraint, encoder, decoder, encoded,
         elapsed   = pairing_last_arr - pairing_dep
         fly       = pairing_fly
         n_legs    = len(current_legs)
-        dead_time = max(elapsed - fly - pairing_rest, 0.0)
+        # dead_time = duty 내부 연결 gap만 (overnight 초과 제외 — LLM eval과 동일 기준)
+        dead_time = pairing_intra_gap
         cost = (dead_time
                 - config.IP_LEG_BONUS * max(n_legs - 1, 0)
                 + (config.IP_DEADHEAD_PENALTY if is_forced else 0.0)
@@ -215,7 +216,9 @@ def rollout_batch(flights, constraint, encoder, decoder, encoded, B=50,
     pair_fly    = [0.0] * B
     pair_arr    = [0.0] * B
     pair_rest   = [0.0] * B
-    pair_duties = [1] * B   # 현재 pairing의 duty 수
+    pair_duties      = [1]   * B   # 현재 pairing의 duty 수
+    pair_intra_gap   = [0.0] * B   # duty 내부 연결 gap (FTC 기준)
+    pair_inter_excess= [0.0] * B   # overnight 초과 대기 (FTC 제외)
     pairings    = [[] for _ in range(B)]
     done        = [False] * B
 
@@ -225,14 +228,17 @@ def rollout_batch(flights, constraint, encoder, decoder, encoded, B=50,
         elapsed = pair_arr[i] - pair_dep[i]
         fly     = pair_fly[i]
         n_legs  = len(cur_legs[i])
-        dead    = max(elapsed - fly - pair_rest[i], 0.0)
+        # dead_time = duty 내부 연결 gap만 (overnight 초과 제외 — LLM eval과 동일 기준)
+        dead    = pair_intra_gap[i]
         cost    = (dead
                    - config.IP_LEG_BONUS * max(n_legs - 1, 0)
                    + (config.IP_DEADHEAD_PENALTY if forced else 0.0)
                    + config.IP_PAIRING_FIXED_COST)
         pairings[i].append({"legs": list(cur_legs[i]), "fly": fly, "elapsed": elapsed,
                              "dead_time": dead, "cost": cost, "is_deadhead": forced,
-                             "n_legs": n_legs, "n_duties": pair_duties[i]})
+                             "n_legs": n_legs, "n_duties": pair_duties[i],
+                             "intra_duty_gap":    pair_intra_gap[i],
+                             "inter_duty_excess": pair_inter_excess[i]})
 
     def start_env(i, f):
         assigned[i][f["id"]] = True
@@ -240,8 +246,10 @@ def rollout_batch(flights, constraint, encoder, decoder, encoded, B=50,
         pair_dep[i]    = f["dep_time"]
         pair_fly[i]    = f["arr_time"] - f["dep_time"]
         pair_arr[i]    = f["arr_time"]
-        pair_rest[i]   = 0.0
-        pair_duties[i] = 1
+        pair_rest[i]        = 0.0
+        pair_duties[i]      = 1
+        pair_intra_gap[i]   = 0.0
+        pair_inter_excess[i]= 0.0
         states[i] = {
             "current_airport":    f["dest"],
             "current_time":       f["arr_time"],
@@ -323,6 +331,12 @@ def rollout_batch(flights, constraint, encoder, decoder, encoded, B=50,
                 cur_legs[i].append(f["id"])
                 pair_fly[i] += f["arr_time"] - f["dep_time"]
                 pair_arr[i]  = f["arr_time"]
+                # gap 종류 분리 집계
+                if not states[i].get("pairing_start", False) and not states[i].get("is_resting", False):
+                    pair_intra_gap[i] += f["dep_time"] - states[i]["current_time"]
+                elif states[i].get("is_resting", False):
+                    rest_end = states[i].get("rest_end_time", f["dep_time"])
+                    pair_inter_excess[i] += max(f["dep_time"] - rest_end, 0.0)
                 states[i], _, done_flag = step(states[i], action, flights, assigned[i], constraint)
                 if done_flag:
                     flush_env(i)

--- a/evaluate_ip.py
+++ b/evaluate_ip.py
@@ -428,7 +428,7 @@ def evaluate_full(
             connected_sampler=connected_sampler,
         )
 
-    print(f"\nIP 풀기 (n_flights={n_total}, pool={len(pool)}, time_limit={ip_time_limit}s, lambda_dh={lambda_dh})...", flush=True)
+    print(f"\nIP 풀기 (n_flights={n_total}, pool={len(pool)}, time_limit={ip_time_limit}s, lambda_dh={lambda_dh}, gap_weight={GAP_COST_WEIGHT})...", flush=True)
     result = solve_set_covering(pool, n_flights=n_total, time_limit=ip_time_limit, lambda_dh=lambda_dh)
 
     sel        = result["selected"]
@@ -439,10 +439,11 @@ def evaluate_full(
     man_days     = sum(math.ceil(p["elapsed"] / 24.0)  for p in sel) if sel else 0
     avg_legs     = legs_total   / len(sel) if sel else 0.0
     avg_duties   = duties_total / len(sel) if sel else 0.0
-    ftc          = dead_total / fly_total * 100 if fly_total > 0 else 0.0
-    # [진단용] dead_time을 duty 내부/duty 간으로 분리 집계
-    intra_gap_total  = sum(p.get("intra_duty_gap", 0.0)    for p in sel) if sel else 0.0
+    # dead_time = elapsed - fly - n_overnights×min_rest → overnight 초과분 포함 (FTC 과다 계산)
+    # FTC는 duty 내부 연결 gap만으로 계산해야 함 → intra_duty_gap 사용
+    intra_gap_total    = sum(p.get("intra_duty_gap", 0.0)    for p in sel) if sel else 0.0
     inter_excess_total = sum(p.get("inter_duty_excess", 0.0) for p in sel) if sel else 0.0
+    ftc = intra_gap_total / fly_total * 100 if fly_total > 0 else 0.0
 
     print()
     print("=" * 60)
@@ -454,10 +455,10 @@ def evaluate_full(
     print(f"  uncoverable:       {result['uncoverable']}개 flight")
     print(f"  deadhead:          {result['deadhead_count']}개 flight")
     print(f"  fly time:          {fly_total:.2f}h")
-    print(f"  dead time:         {dead_total:.2f}h")
-    print(f"    - duty 내부 연결 gap:     {intra_gap_total:.2f}h ({intra_gap_total/dead_total*100 if dead_total>0 else 0:.1f}%)")
-    print(f"    - duty 간 초과 대기(>min_rest): {inter_excess_total:.2f}h ({inter_excess_total/dead_total*100 if dead_total>0 else 0:.1f}%)")
-    print(f"  FTC:               {ftc:.2f}%")
+    print(f"  dead time (total): {dead_total:.2f}h")
+    print(f"    intra-duty gap:  {intra_gap_total:.2f}h  ← FTC 기준")
+    print(f"    overnight excess:{inter_excess_total:.2f}h  (실제 overnight - min_rest)")
+    print(f"  FTC:               {ftc:.2f}%  (= intra-duty gap / fly)")
     print(f"  avg legs/pairing:  {avg_legs:.2f}")
     print(f"  avg duties/pairing:{avg_duties:.2f}")
     print(f"  IP status:         {result['status']}")

--- a/evaluate_ip.py
+++ b/evaluate_ip.py
@@ -428,7 +428,7 @@ def evaluate_full(
             connected_sampler=connected_sampler,
         )
 
-    print(f"\nIP 풀기 (n_flights={n_total}, pool={len(pool)}, time_limit={ip_time_limit}s, lambda_dh={lambda_dh}, gap_weight={GAP_COST_WEIGHT})...", flush=True)
+    print(f"\nIP 풀기 (n_flights={n_total}, pool={len(pool)}, time_limit={ip_time_limit}s, lambda_dh={lambda_dh}", flush=True)
     result = solve_set_covering(pool, n_flights=n_total, time_limit=ip_time_limit, lambda_dh=lambda_dh)
 
     sel        = result["selected"]


### PR DESCRIPTION
  ## 문제         
rollout.py에서 dead_time을 `elapsed - fly - n_overnights × min_rest`로 계산해서 overnight 실제 휴식이 min_rest(10h)보다 길면 초과분이 dead_time에 포함됨
→ FTC가 최대 171%까지 비정상적으로 높게 측정되던 버그 존재

## 수정 내용
  ### RL/rollout.py                                                             
  - `rollout_with_pairings`, `rollout_batch` 모두 수정
  - `dead_time = elapsed - fly - pairing_rest` → `dead_time = pairing_intra_gap`
  - pairing dict에 `intra_duty_gap`, `inter_duty_excess` 필드 추가

 ### evaluate_ip.py
  - FTC 계산: `dead_total / fly_total` → `intra_gap_total / fly_total`
  - 출력에 intra-duty gap / overnight excess 분리 표